### PR TITLE
fix: swap download/upload columns in leaderboard (rx=server-received=upload, tx=server-sent=download)

### DIFF
--- a/app.py
+++ b/app.py
@@ -568,11 +568,11 @@ def get_leaderboard_entries(data: dict, period: str) -> list[dict]:
         if u.get("enabled", True) is not True:
             continue
         if period == "monthly":
-            download = u.get("monthly_rx", 0)
-            upload = u.get("monthly_tx", 0)
+            download = u.get("monthly_tx", 0)  # server-sent = client download
+            upload = u.get("monthly_rx", 0)  # server-received = client upload
         else:
-            download = u.get("traffic_total_rx", 0)
-            upload = u.get("traffic_total_tx", 0)
+            download = u.get("traffic_total_tx", 0)  # server-sent = client download
+            upload = u.get("traffic_total_rx", 0)  # server-received = client upload
         total = download + upload
         # Skip zero-traffic users
         if total == 0:

--- a/tests/test_leaderboard.py
+++ b/tests/test_leaderboard.py
@@ -270,7 +270,7 @@ class TestGetLeaderboardEntries:
     def test_invalid_period_defaults_to_all_time(self, app_module):
         data = {
             "users": [
-                _make_user("alice", traffic_total_rx=100, monthly_rx=999),
+                _make_user("alice", traffic_total_tx=100, monthly_rx=999),
             ]
         }
         entries = app_module.get_leaderboard_entries(data, "invalid-period")
@@ -283,8 +283,9 @@ class TestGetLeaderboardEntries:
             ]
         }
         entries = app_module.get_leaderboard_entries(data, "all-time")
-        assert entries[0]["download"] == 3000
-        assert entries[0]["upload"] == 2000
+        # tx = server-sent = client download, rx = server-received = client upload
+        assert entries[0]["download"] == 2000
+        assert entries[0]["upload"] == 3000
         assert entries[0]["total"] == 5000
 
 
@@ -387,7 +388,7 @@ class TestLeaderboardAPI:
     def test_invalid_period_defaults_to_all_time(self, client, app_module):
         data = {
             "users": [
-                _make_user("alice", traffic_total_rx=100, monthly_rx=9999),
+                _make_user("alice", traffic_total_tx=100, monthly_rx=9999),
             ]
         }
         with open(app_module.DATA_FILE, "w") as f:
@@ -461,8 +462,9 @@ class TestLeaderboardAPI:
             assert isinstance(entry["download"], int)
             assert isinstance(entry["upload"], int)
             assert isinstance(entry["total"], int)
-            assert entry["download"] == 5368709120
-            assert entry["upload"] == 1073741824
+            # tx = server-sent = client download, rx = server-received = client upload
+            assert entry["download"] == 1073741824
+            assert entry["upload"] == 5368709120
 
 
 # ---------- Page Route Tests ----------


### PR DESCRIPTION
## What
Fixed Download and Upload columns being swapped in the leaderboard table

## Why
WireGuard wg show reports rx/tx from the server perspective — rx (received by server) equals client upload, tx (sent by server) equals client download. The code had them mapped backwards.

## Technical approach
Swapped the rx/tx lookup in get_leaderboard_entries() so download uses _tx fields and upload uses _rx fields. Updated corresponding test assertions. Traffic sync code is unchanged.

## Testing
41 leaderboard tests pass + 35 traffic rxtx tests pass. No regression in data accumulation.
How verified: pytest, py_compile, black, flake8, pip-audit all pass

Closes #