### PR TITLE
fix: change Telemt proxy default port from 443 to 18443

### DIFF
--- a/protocol_telemt/config.toml
+++ b/protocol_telemt/config.toml
@@ -25,7 +25,7 @@ show = "*"
 # show = ["alice", "bob"] # Only show links for alice and bob
 # show = "*"              # Show links for all users
 # public_host = "proxy.example.com"  # Host (IP or domain) for tg:// links
-public_port = 443                  # Port for tg:// links (default: server.port)
+public_port = 18443                  # Port for tg:// links (default: server.port)
 
 # === Server Binding ===
 [server]

--- a/telemt_manager.py
+++ b/telemt_manager.py
@@ -75,7 +75,7 @@ class TelemtManager:
     def install_protocol(
         self,
         protocol_type="telemt",
-        port="443",
+        port="18443",
         tls_emulation=True,
         tls_domain="",
         max_connections=0,

--- a/templates/server.html
+++ b/templates/server.html
@@ -815,8 +815,8 @@
             portHint.textContent = _('port_xray_hint');
         } else if (proto === 'telemt') {
             portLabel.textContent = _('port') + ' (TCP)';
-            portInput.value = '443';
-            portHint.textContent = 'Порт для Telegram-прокси (обычно 443)';
+            portInput.value = '18443';
+            portHint.textContent = 'Порт для Telegram-прокси (обычно 18443)';
             telemtOpts.style.display = 'block';
         } else {
             portLabel.textContent = _('port') + ' (UDP)';


### PR DESCRIPTION
## What

Changes the default external port for the Telemt (MTProxy) protocol from 443 to 18443 across configuration, logic, and UI.

## Why

Telemt proxy connection links (`tg://proxy?server=...&port=443&secret=...`) were defaulting to port 443. The correct external port should be 18443. This caused proxy links to be non-functional when users accepted the default.

## Technical approach

Three files changed, all switching the default external port from 443 → 18443:

1. **`telemt_manager.py:78`** — `install_protocol(port="443")` → `port="18443"`
2. **`templates/server.html:818-819`** — UI default value and hint text updated
3. **`protocol_telemt/config.toml:28`** — `public_port = 443` → `18443`

Internal container ports (Docker port 443, daemon listen port 443) are intentionally left unchanged — they are correct as-is since they represent the container-internal port, not the external-facing one.

## Testing

- `python3 -m py_compile telemt_manager.py` — passed
- QA review verified all 3 changes correct, all 5 internal port references unchanged
- Port flow verified end-to-end: UI → API → install → storage → link generation

## How verified

- Git diff: exactly 3 files, 4 lines changed, no unintended modifications
- QA review: full code path analysis confirmed port 18443 flows correctly through all layers
- Internal ports (443) in Dockerfile, docker-compose, config.toml line 32 — all confirmed unchanged

Closes #15