### PR TITLE
fix(docker): include schema.sql in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy application code and assets
 COPY *.py ./
+COPY schema.sql ./
 COPY static/ ./static/
 COPY templates/ ./templates/
 COPY translations/ ./translations/


### PR DESCRIPTION
## What
The SQLite migration added `schema.sql` but the Dockerfile only copied `*.py` files. This caused a `FileNotFoundError` on startup in Docker:

```
FileNotFoundError: schema.sql not found at /app/schema.sql
```

## Fix
Add `COPY schema.sql ./` to the Dockerfile after the `COPY *.py ./` line.

## Testing
- `app.py` compiles cleanly
- `schema.sql` will now be available at `/app/schema.sql` in the Docker image
- `migrate_to_sqlite.py` is already covered by the `COPY *.py ./` glob