### PR TITLE
fix(sqlite): add missing migrate_if_needed function and update telemt tests

### DIFF
--- a/migrate_to_sqlite.py
+++ b/migrate_to_sqlite.py
@@ -18,6 +18,29 @@ import sys
 logger = logging.getLogger(__name__)
 
 
+def migrate_if_needed(data_dir: str) -> None:
+    """Check if migration is needed and run it.
+
+    Called by app.py on startup. Three cases:
+    1. panel.db exists → skip (already migrated)
+    2. data.json exists → migrate to panel.db, rename data.json → data.json.bak
+    3. Neither exists → skip (fresh install, Database.__init__ will create panel.db)
+    """
+    data_file = os.path.join(data_dir, "data.json")
+    db_path = os.path.join(data_dir, "panel.db")
+
+    if os.path.exists(db_path):
+        logger.info("panel.db already exists, skipping migration")
+        return
+
+    if not os.path.exists(data_file):
+        logger.info("No data.json found. Fresh install — panel.db will be created on first use.")
+        return
+
+    logger.info("data.json found without panel.db — running migration")
+    migrate_data_json_to_sqlite(data_file, db_path)
+
+
 def migrate_data_json_to_sqlite(data_file: str, db_path: str) -> None:
     """Migrate data.json to panel.db. Raises on failure.
 

--- a/tests/test_api_connections.py
+++ b/tests/test_api_connections.py
@@ -243,8 +243,7 @@ class TestApiAddConnectionTelemtFailure:
             "settings": {},
         }
 
-    @patch("app.load_data")
-    @patch("app.save_data")
+    @patch("app.get_db")
     @patch("app._check_admin")
     @patch("app.get_ssh")
     @patch("app.get_protocol_manager")
@@ -253,12 +252,16 @@ class TestApiAddConnectionTelemtFailure:
         mock_get_protocol_manager,
         mock_get_ssh,
         mock_check_admin,
-        mock_save_data,
-        mock_load_data,
+        mock_get_db,
     ):
-        """When telemt API fails, return 500 and do NOT write to data.json."""
+        """When telemt API fails, return 500 and do NOT write to database."""
+        mock_db = MagicMock()
+        mock_db.get_server_by_index.return_value = self.mock_data["servers"][0]
+        mock_db.get_all_users.return_value = []
+        mock_db.get_connections_by_user.return_value = []
+        mock_db.get_setting.return_value = {}
+        mock_get_db.return_value = mock_db
         mock_check_admin.return_value = True
-        mock_load_data.return_value = self.mock_data.copy()
 
         mock_ssh = MagicMock()
         mock_get_ssh.return_value = mock_ssh
@@ -282,11 +285,10 @@ class TestApiAddConnectionTelemtFailure:
         data = response.json()
         assert "error" in data
         assert data["error"] == "User already exists"
-        # Verify save_data was never called (no connection written)
-        mock_save_data.assert_not_called()
+        # Verify create_connection was never called (no connection written)
+        mock_db.create_connection.assert_not_called()
 
-    @patch("app.load_data")
-    @patch("app.save_data")
+    @patch("app.get_db")
     @patch("app._check_admin")
     @patch("app.get_ssh")
     @patch("app.get_protocol_manager")
@@ -295,12 +297,16 @@ class TestApiAddConnectionTelemtFailure:
         mock_get_protocol_manager,
         mock_get_ssh,
         mock_check_admin,
-        mock_save_data,
-        mock_load_data,
+        mock_get_db,
     ):
-        """When telemt API succeeds, connection is written to data.json."""
+        """When telemt API succeeds, connection is written to database."""
+        mock_db = MagicMock()
+        mock_db.get_server_by_index.return_value = self.mock_data["servers"][0]
+        mock_db.get_all_users.return_value = []
+        mock_db.get_connections_by_user.return_value = []
+        mock_db.get_setting.return_value = {}
+        mock_get_db.return_value = mock_db
         mock_check_admin.return_value = True
-        mock_load_data.return_value = self.mock_data.copy()
 
         mock_ssh = MagicMock()
         mock_get_ssh.return_value = mock_ssh
@@ -319,5 +325,5 @@ class TestApiAddConnectionTelemtFailure:
         )
 
         assert response.status_code == 200
-        # Verify save_data was called (connection written)
-        mock_save_data.assert_called_once()
+        # Verify create_connection was called (connection written)
+        mock_db.create_connection.assert_called_once()


### PR DESCRIPTION
## What
Fix two deployment-breaking bugs from the SQLite migration (PR #26):

### Bug 1: Missing `migrate_if_needed()` function
`app.py` line 110 calls `migrate_to_sqlite.migrate_if_needed(DATA_DIR)` on startup, but the function didn't exist. The migration script only had `migrate_data_json_to_sqlite()` for standalone use. This caused:
```
AttributeError: module 'migrate_to_sqlite' has no attribute 'migrate_if_needed'
```

**Fix:** Added `migrate_if_needed()` that handles three cases:
- `panel.db` exists → skip (already migrated)
- `data.json` exists → run migration, rename to `.bak`
- Neither → fresh install, DB created on first use

### Bug 2: Two telemt tests still mocked `load_data`/`save_data`
`test_api_connections.py` had 2 tests from Issue #22 that still used `@patch("app.load_data")` and `@patch("app.save_data")`, which no longer exist after SQLite migration. Updated to mock `app.get_db()` with Database methods.

## Testing
- 173/173 tests pass
- `py_compile` passes for all modified files

Covers issues reported in production deployment.