### PR TITLE
fix(api): restore missing fields in AddUserRequest model

### DIFF
--- a/app.py
+++ b/app.py
@@ -594,9 +594,11 @@ class AddUserRequest(BaseModel):
     email: Optional[str] = None
     description: Optional[str] = None
     traffic_limit: Optional[float] = 0
-    traffic_reset_strategy: Optional[str] = None
+    traffic_reset_strategy: Optional[str] = "never"
+    server_id: Optional[int] = None
+    protocol: Optional[str] = None
+    connection_name: Optional[str] = None
     expiration_date: Optional[str] = None
-    password: Optional[str] = None
 
 
 class ServerConfigSaveRequest(BaseModel):


### PR DESCRIPTION
The SQLite migration truncated the AddUserRequest Pydantic model, removing server_id, protocol, and connection_name fields. This caused AttributeError when the auto-connection logic tried to access req.server_id.

Also fixed:
- Restored traffic_reset_strategy default to 'never' (was None)
- Removed duplicate password field that overrode the required one

Original model had these fields; they were lost during the app.py rewrite in PR #26.