### PR TITLE
Fix: use server.id (not srv.id) in index.html templates

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -15,7 +15,7 @@
     {% if servers %}
     <div class="server-grid" id="serverGrid">
         {% for server in servers %}
-        <div class="card card-hover server-card" id="server-{{ loop.index0 }}">
+        <div class="card card-hover server-card" id="server-{{ server.id }}">
             <div class="server-meta">
                 <div class="server-icon">🖥</div>
                 <div>
@@ -24,7 +24,7 @@
                 </div>
             </div>
 
-            <div class="server-protocols" id="server-protocols-{{ loop.index0 }}">
+            <div class="server-protocols" id="server-protocols-{{ server.id }}">
                 {% if server.protocols %}
                 {% for proto_key, proto_val in server.protocols.items() %}
                 {% if proto_val.get('installed') %}
@@ -44,10 +44,10 @@
             </div>
 
             <div class="server-actions">
-                <a href="/server/{{ srv.id }}" class="btn btn-secondary btn-sm" style="flex:1">
+                <a href="/server/{{ server.id }}" class="btn btn-secondary btn-sm" style="flex:1">
                     {{ _('manage') }}
                 </a>
-                <button class="btn btn-danger btn-sm btn-icon" onclick="deleteServer({{ srv.id }})"
+                <button class="btn btn-danger btn-sm btn-icon" onclick="deleteServer({{ server.id }})"
                     title="{{ _('delete') }}">
                     🗑
                 </button>


### PR DESCRIPTION
## Root Cause
The for-loop variable is `server`, not `srv`. The merged PR #39 used `srv.id` which is undefined in Jinja2, causing `UndefinedError: 'srv' is undefined`.

Also fixed remaining `loop.index0` usages in card-id and protocols-div attributes.

## Changes
- `/server/{{ srv.id }}` → `/server/{{ server.id }}` (manage link)
- `deleteServer({{ srv.id }})` → `deleteServer({{ server.id }})` (delete button)
- `id="server-{{ loop.index0 }}"` → `id="server-{{ server.id }}"` (card DOM id)
- `id="server-protocols-{{ loop.index0 }}"` → `id="server-protocols-{{ server.id }}"` (protocols div id)