### PR TITLE
Phase 1 Security Fixes (Batches 1A-1D)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ telemt_task_*/
 leaderboard/
 screen/
 WORKLOG.md
+.secret_key
+=0.9.0

--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ import secrets
 import uuid
 import asyncio
 from datetime import datetime
+from pathlib import Path
 import io
 from fastapi.responses import (
     JSONResponse,
@@ -35,6 +36,7 @@ from ssh_manager import SSHManager
 from awg_manager import AWGManager
 from xray_manager import XrayManager
 from database import Database
+from starlette_csrf import CSRFMiddleware
 import telegram_bot as tg_bot
 
 # Configure logging
@@ -42,18 +44,8 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 app = FastAPI(title="Amnezia Web Panel")
-app.add_middleware(
-    SessionMiddleware, secret_key=os.environ.get("SECRET_KEY", secrets.token_hex(32))
-)
 
-# Mount static files & templates
-app.mount(
-    "/static",
-    StaticFiles(directory=os.path.join(os.path.dirname(__file__), "static")),
-    name="static",
-)
-templates = Jinja2Templates(directory=os.path.join(os.path.dirname(__file__), "templates"))
-
+# Define DATA_DIR early so it can be used by _get_secret_key()
 if getattr(sys, "frozen", False):
     application_path = os.path.dirname(sys.executable)
 else:
@@ -61,6 +53,143 @@ else:
 
 DATA_DIR = application_path
 DB_PATH = os.path.join(DATA_DIR, "panel.db")
+
+# ======================== SECRET_KEY Initialization ========================
+# SECRET_KEY is used for session encryption. We need a persistent key that survives
+# restarts. Priority: env var > file > generate new (with warning)
+
+
+def _get_secret_key() -> str:
+    """Get or generate a persistent SECRET_KEY.
+
+    Priority:
+    1. SECRET_KEY environment variable (highest priority, for production/Docker)
+    2. .secret_key file in application directory (persistence across restarts)
+    3. Generate new key and save to file (first boot scenario, logs warning)
+
+    The file-based approach ensures the key persists across container restarts
+    when using Docker volumes.
+    """
+    # 1. Check environment variable first
+    env_key = os.environ.get("SECRET_KEY")
+    if env_key:
+        logger.info("Using SECRET_KEY from environment variable")
+        return env_key
+
+    # 2. Check for existing key file
+    key_file = Path(DATA_DIR) / ".secret_key"
+    if key_file.exists():
+        try:
+            stored_key = key_file.read_text().strip()
+            if stored_key:
+                logger.info("Loaded SECRET_KEY from persistent storage")
+                return stored_key
+        except Exception as e:
+            logger.warning(f"Failed to read SECRET_KEY from file: {e}")
+
+    # 3. Generate new key and save to file
+    new_key = secrets.token_hex(32)
+    try:
+        key_file.write_text(new_key)
+        # Ensure file permissions are restrictive (owner read/write only)
+        os.chmod(key_file, 0o600)
+        logger.warning(
+            "Generated new SECRET_KEY on first boot. "
+            "Set SECRET_KEY environment variable for production to prevent this warning. "
+            "Key stored in: %s",
+            key_file,
+        )
+    except Exception as e:
+        logger.error("Failed to save generated SECRET_KEY to file: %s", e)
+
+    return new_key
+
+
+# Password change required middleware
+# Blocks all /api/ requests (except auth endpoints) for users who must change their password
+# MUST be added BEFORE SessionMiddleware so it runs AFTER SessionMiddleware on request path
+# (add_middleware: last added = outermost = runs first on request)
+_PASSWORD_CHANGE_ALLOWED_PATHS = {
+    "/api/auth/login",
+    "/api/auth/change-password",
+    "/api/auth/captcha",
+}
+
+
+class PasswordChangeRequiredMiddleware:
+    """ASGI middleware that blocks API access for users with password_change_required flag.
+
+    Allows through: /api/auth/login, /api/auth/change-password, /api/auth/captcha,
+    all non-API paths (static, pages), and unauthenticated requests.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        # Peek at the path without constructing a full Request yet
+        path = scope.get("path", "")
+        if not path.startswith("/api/") or path in _PASSWORD_CHANGE_ALLOWED_PATHS:
+            await self.app(scope, receive, send)
+            return
+
+        # We need Request for session access - construct it
+        from starlette.requests import Request as StarletteRequest
+
+        request = StarletteRequest(scope, receive, send)
+        user_id = request.session.get("user_id")
+        if not user_id:
+            await self.app(scope, receive, send)
+            return
+
+        try:
+            db = get_db()
+            user = db.get_user(user_id)
+            if user and user.get("password_change_required", False):
+                response = JSONResponse(
+                    {"error": "Password change required", "password_change_required": True},
+                    status_code=403,
+                )
+                await response(scope, receive, send)
+                return
+        except Exception:
+            # If session or DB access fails, let the request through
+            pass
+
+        await self.app(scope, receive, send)
+
+
+app.add_middleware(PasswordChangeRequiredMiddleware)
+
+app.add_middleware(SessionMiddleware, secret_key=_get_secret_key())
+
+# Add CSRF protection middleware
+# safe_methods: GET, OPTIONS, HEAD, TRACE are considered safe and don't require CSRF
+# All other methods (POST, PUT, DELETE, PATCH) require a valid CSRF token
+# Note: /api/my/* and /api/servers/* use session-based auth (cookies) and ARE protected
+app.add_middleware(
+    CSRFMiddleware,
+    secret=_get_secret_key(),
+    safe_methods={"GET", "OPTIONS", "HEAD", "TRACE"},
+    cookie_name="csrftoken",
+    cookie_path="/",
+    cookie_samesite="lax",
+    header_name="x-csrftoken",
+)
+
+
+# Password change required middleware
+# Mount static files & templates
+app.mount(
+    "/static",
+    StaticFiles(directory=os.path.join(os.path.dirname(__file__), "static")),
+    name="static",
+)
+templates = Jinja2Templates(directory=os.path.join(os.path.dirname(__file__), "templates"))
 
 
 # ======================== Translations ========================
@@ -480,6 +609,8 @@ def tpl(request, template, **kwargs):
         "translations_json": json.dumps(TRANSLATIONS.get(lang, TRANSLATIONS.get("en", {}))),
         "all_translations_json": json.dumps(TRANSLATIONS),
         "format_bytes": _format_bytes,
+        # CSRF token for forms - available from cookie, set by CSRF middleware
+        "csrf_token": request.cookies.get("csrftoken", ""),
     }
     ctx.update(kwargs)
     return templates.TemplateResponse(template, ctx)
@@ -685,6 +816,12 @@ class AddUserConnectionRequest(BaseModel):
     telemt_expiry: Optional[str] = None
 
 
+class ChangePasswordRequest(BaseModel):
+    current_password: str
+    new_password: str
+    confirm_password: str
+
+
 class ShareSetupRequest(BaseModel):
     enabled: bool
     password: Optional[str] = None
@@ -703,17 +840,27 @@ async def startup():
     db = get_db()
 
     if not db.get_all_users():
+        temp_password = secrets.token_urlsafe(12)
         db.create_user(
             {
                 "id": str(uuid.uuid4()),
                 "username": "admin",
-                "password_hash": hash_password("admin"),
+                "password_hash": hash_password(temp_password),
                 "role": "admin",
                 "enabled": True,
+                "password_change_required": True,
                 "created_at": datetime.now().isoformat(),
             }
         )
-        logger.info("Default admin created (admin / admin)")
+        print(f"\n{'=' * 60}")
+        print("  INITIAL ADMIN CREDENTIALS — SAVE THIS NOW")
+        print("  Username: admin")
+        print(f"  Password: {temp_password}")
+        print("  You must change this password on first login.")
+        print(f"{'=' * 60}\n")
+        logger.info("Default admin created with random password (password_change_required=True)")
+    else:
+        logger.info("Existing users found, skipping default admin creation")
 
     # Start periodic background tasks
     asyncio.create_task(periodic_background_tasks())
@@ -1092,9 +1239,44 @@ async def api_login(request: Request, req: LoginRequest):
         if not user.get("enabled", True):
             return JSONResponse({"error": _t("account_disabled", lang)}, status_code=403)
         request.session["user_id"] = user["id"]
-        return {"status": "success", "role": user["role"]}
+        return {
+            "status": "success",
+            "role": user["role"],
+            "password_change_required": user.get("password_change_required", False),
+        }
     lang = request.cookies.get("lang", "ru")
     return JSONResponse({"error": _t("invalid_login", lang)}, status_code=401)
+
+
+@app.post("/api/auth/change-password")
+async def api_change_password(request: Request, req: ChangePasswordRequest):
+    """Change password for the currently authenticated user.
+
+    Clears password_change_required flag on success.
+    """
+    user = get_current_user(request)
+    if not user:
+        return JSONResponse({"error": "unauthorized"}, status_code=401)
+
+    if not verify_password(req.current_password, user["password_hash"]):
+        return JSONResponse({"error": "Current password is incorrect"}, status_code=400)
+
+    if req.new_password != req.confirm_password:
+        return JSONResponse({"error": "New passwords do not match"}, status_code=400)
+
+    if len(req.new_password) < 8:
+        return JSONResponse({"error": "Password must be at least 8 characters"}, status_code=400)
+
+    db = get_db()
+    db.update_user(
+        user["id"],
+        {
+            "password_hash": hash_password(req.new_password),
+            "password_change_required": False,
+        },
+    )
+    logger.info(f"User '{user['username']}' changed their password")
+    return {"status": "success"}
 
 
 @app.get("/api/leaderboard")

--- a/awg_manager.py
+++ b/awg_manager.py
@@ -942,10 +942,7 @@ AllowedIPs = {client_ip}/32
                     continue
                 config_lines.append(f"{config_key} = {val}")
 
-        client_config = (
-            "[Interface]\n"
-            + "\n".join(config_lines)
-            + f"""
+        client_config = "[Interface]\n" + "\n".join(config_lines) + f"""
 
 [Peer]
 PublicKey = {server_pub_key}
@@ -954,7 +951,6 @@ AllowedIPs = 0.0.0.0/0, ::/0
 Endpoint = {server_host}:{port}
 PersistentKeepalive = 25
 """
-        )
 
         return {
             "client_name": client_name,
@@ -1041,10 +1037,7 @@ PersistentKeepalive = 25
                     continue
                 config_lines.append(f"{config_key} = {val}")
 
-        config = (
-            "[Interface]\n"
-            + "\n".join(config_lines)
-            + f"""
+        config = "[Interface]\n" + "\n".join(config_lines) + f"""
 
 [Peer]
 PublicKey = {server_pub_key}
@@ -1053,7 +1046,6 @@ AllowedIPs = 0.0.0.0/0, ::/0
 Endpoint = {server_host}:{port}
 PersistentKeepalive = 25
 """
-        )
         return config
 
     def toggle_client(self, protocol_type, client_id, enable):

--- a/database.py
+++ b/database.py
@@ -36,6 +36,68 @@ def _rows_to_dicts(rows: List[sqlite3.Row]) -> List[Dict[str, Any]]:
 class Database:
     """Thread-safe SQLite wrapper with WAL mode and typed CRUD methods."""
 
+    # ----------------------------------------------------------------
+    # Column allowlists for update methods (SQL injection prevention)
+    # See: tasks/sql-injection-column-names/spec.md
+    # ----------------------------------------------------------------
+    ALLOWED_SERVER_COLUMNS = frozenset(
+        {
+            "name",
+            "host",
+            "ssh_user",
+            "ssh_port",
+            "ssh_pass",
+            "ssh_key",
+            "protocols",
+            "created_at",
+        }
+    )
+
+    ALLOWED_USER_COLUMNS = frozenset(
+        {
+            "username",
+            "email",
+            "telegramId",
+            "description",
+            "password_hash",
+            "role",
+            "enabled",
+            "traffic_limit",
+            "traffic_used",
+            "traffic_total",
+            "traffic_total_rx",
+            "traffic_total_tx",
+            "monthly_rx",
+            "monthly_tx",
+            "monthly_reset_at",
+            "traffic_reset_strategy",
+            "share_enabled",
+            "share_token",
+            "share_password_hash",
+            "remnawave_uuid",
+            "created_at",
+            "last_reset_at",
+            "expiration_date",
+            "password_change_required",
+            "limits",
+        }
+    )
+
+    ALLOWED_CONNECTION_COLUMNS = frozenset(
+        {
+            "user_id",
+            "server_id",
+            "protocol",
+            "client_id",
+            "name",
+            "last_rx",
+            "last_tx",
+            "traffic_delta_rx",
+            "traffic_delta_tx",
+            "created_at",
+        }
+    )
+
     def __init__(self, db_path: str) -> None:
         self.db_path = db_path
         self._local = threading.local()
@@ -64,10 +126,26 @@ class Database:
             raise FileNotFoundError(f"schema.sql not found at {SCHEMA_PATH}")
         conn.commit()
 
+        # Run schema migrations for existing databases
+        self._run_migrations(conn)
+
         # Populate default settings on fresh installs
         self._ensure_default_settings()
 
         logger.info("Database initialized: %s", self.db_path)
+
+    def _run_migrations(self, conn: sqlite3.Connection) -> None:
+        """Run schema migrations for existing databases that may lack newer columns."""
+        # Migration: add password_change_required column to users table
+        try:
+            conn.execute("SELECT password_change_required FROM users LIMIT 1")
+        except sqlite3.OperationalError:
+            logger.info("Migrating users table: adding password_change_required column")
+            conn.execute(
+                "ALTER TABLE users ADD COLUMN password_change_required "
+                "INTEGER NOT NULL DEFAULT 0"
+            )
+            conn.commit()
 
     # ----------------------------------------------------------------
     # Default settings
@@ -177,15 +255,20 @@ class Database:
 
     def update_server(self, server_id: int, updates: Dict[str, Any]) -> None:
         """Update a server by its database id."""
+        # Validate column names against allowlist to prevent SQL injection
+        unknown = set(updates.keys()) - self.ALLOWED_SERVER_COLUMNS
+        if unknown:
+            raise ValueError(f"Unknown server columns: {', '.join(sorted(unknown))}")
+
         conn = self._get_conn()
-        # Map common field names
+        # Map common field names to DB column names
         field_map = {
             "name": "name",
             "host": "host",
             "username": "ssh_user",
             "ssh_user": "ssh_user",
             "ssh_port": "ssh_port",
-            "password": "ssh_pass",
+            "password": "***",
             "ssh_pass": "ssh_pass",
             "private_key": "ssh_key",
             "ssh_key": "ssh_key",
@@ -229,8 +312,40 @@ class Database:
             "UPDATE user_connections SET server_id = server_id - 1 " "WHERE server_id > ?",
             (index,),
         )
+        # Remove known host entry for this server
+        conn.execute("DELETE FROM known_hosts WHERE server_id = ?", (db_id,))
         conn.commit()
         return True
+
+    # ----------------------------------------------------------------
+    # Known Hosts
+    # ----------------------------------------------------------------
+
+    def get_known_host_fingerprint(self, server_id: int) -> Optional[str]:
+        """Return the stored fingerprint for a server, or None if unknown."""
+        conn = self._get_conn()
+        row = conn.execute(
+            "SELECT fingerprint FROM known_hosts WHERE server_id = ?", (server_id,)
+        ).fetchone()
+        return row["fingerprint"] if row else None
+
+    def save_known_host_fingerprint(self, server_id: int, fingerprint: str) -> None:
+        """Store or update the host key fingerprint for a server."""
+        conn = self._get_conn()
+        conn.execute(
+            """INSERT INTO known_hosts (server_id, fingerprint)
+               VALUES (?, ?)
+               ON CONFLICT(server_id) DO UPDATE SET fingerprint = excluded.fingerprint""",
+            (server_id, fingerprint),
+        )
+        conn.commit()
+
+    def delete_known_host(self, server_id: int) -> bool:
+        """Delete the known host entry for a server. Returns True if deleted."""
+        conn = self._get_conn()
+        cur = conn.execute("DELETE FROM known_hosts WHERE server_id = ?", (server_id,))
+        conn.commit()
+        return cur.rowcount > 0
 
     def _server_row_to_dict(self, row: sqlite3.Row) -> Dict[str, Any]:
         """Convert a server row, deserializing JSON fields."""
@@ -291,10 +406,10 @@ class Database:
                monthly_rx, monthly_tx, monthly_reset_at,
                traffic_reset_strategy, share_enabled, share_token,
                share_password_hash, remnawave_uuid, created_at,
-               last_reset_at, expiration_date, limits)
+               last_reset_at, expiration_date, password_change_required, limits)
                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
                        ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                       ?, ?, ?, ?, ?)""",
+                       ?, ?, ?, ?, ?, ?)""",
             (
                 user.get("id", ""),
                 user.get("username", ""),
@@ -320,6 +435,7 @@ class Database:
                 user.get("created_at", datetime.now().isoformat()),
                 user.get("last_reset_at", datetime.now().isoformat()),
                 user.get("expiration_date"),
+                1 if user.get("password_change_required", False) else 0,
                 limits_json,
             ),
         )
@@ -328,11 +444,16 @@ class Database:
 
     def update_user(self, user_id: str, updates: Dict[str, Any]) -> bool:
         """Update a user by id with the given fields. Returns True if found."""
+        # Validate column names against allowlist to prevent SQL injection
+        unknown = set(updates.keys()) - self.ALLOWED_USER_COLUMNS
+        if unknown:
+            raise ValueError(f"Unknown user columns: {', '.join(sorted(unknown))}")
+
         conn = self._get_conn()
         if not conn.execute("SELECT 1 FROM users WHERE id = ?", (user_id,)).fetchone():
             return False
 
-        bool_fields = {"enabled", "share_enabled"}
+        bool_fields = {"enabled", "share_enabled", "password_change_required"}
         json_fields = {"limits"}
 
         set_clauses = []
@@ -372,6 +493,8 @@ class Database:
             d["enabled"] = bool(d["enabled"])
         if "share_enabled" in d:
             d["share_enabled"] = bool(d["share_enabled"])
+        if "password_change_required" in d:
+            d["password_change_required"] = bool(d["password_change_required"])
         # Deserialize JSON fields
         if "limits" in d and isinstance(d["limits"], str):
             d["limits"] = json.loads(d["limits"])
@@ -453,6 +576,11 @@ class Database:
 
     def update_connection(self, conn_id: str, updates: Dict[str, Any]) -> bool:
         """Update a connection by id with the given fields. Returns True if found."""
+        # Validate column names against allowlist to prevent SQL injection
+        unknown = set(updates.keys()) - self.ALLOWED_CONNECTION_COLUMNS
+        if unknown:
+            raise ValueError(f"Unknown connection columns: {', '.join(sorted(unknown))}")
+
         conn = self._get_conn()
         if not conn.execute("SELECT 1 FROM user_connections WHERE id = ?", (conn_id,)).fetchone():
             return False

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,13 @@ services:
     ports:
       - "${APP_PORT:-5000}:5000"
     restart: unless-stopped
-
+    volumes:
+      # Mount for persistent SECRET_KEY storage across container restarts
+      - ./data:/app/data
+    environment:
+      # SECRET_KEY should be set in production! Generate with:
+      # python -c "import secrets; print(secrets.token_hex(32))"
+      - SECRET_KEY=${SECRET_KEY:-}
     healthcheck:
       test: ["CMD-SHELL", "python3 -c \"import socket; s=socket.socket(); s.connect(('localhost', 5000)); s.close()\""]
       interval: 30s

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,6 +52,7 @@ rich==14.3.3
 sniffio==1.3.1
 sortedcontainers==2.4.0
 starlette==0.49.1
+starlette-csrf==3.0.0
 tomli==2.4.1
 tomli_w==1.2.0
 typing-inspection==0.4.2

--- a/schema.sql
+++ b/schema.sql
@@ -37,6 +37,7 @@ CREATE TABLE IF NOT EXISTS users (
     created_at TEXT,
     last_reset_at TEXT,
     expiration_date TEXT,
+    password_change_required INTEGER NOT NULL DEFAULT 0,
     limits TEXT  -- JSON blob for per-user limits override
 );
 
@@ -74,3 +75,10 @@ CREATE TABLE IF NOT EXISTS migration_flags (
 CREATE INDEX IF NOT EXISTS idx_user_connections_user_id ON user_connections(user_id);
 CREATE INDEX IF NOT EXISTS idx_user_connections_server_id ON user_connections(server_id);
 CREATE INDEX IF NOT EXISTS idx_creation_log_user_time ON connection_creation_log(user_id, created_at);
+
+CREATE TABLE IF NOT EXISTS known_hosts (
+    server_id INTEGER PRIMARY KEY,
+    fingerprint TEXT NOT NULL,
+    first_seen TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (server_id) REFERENCES servers(id)
+);

--- a/ssh_manager.py
+++ b/ssh_manager.py
@@ -6,14 +6,30 @@ Replicates the ServerController logic from the AmneziaVPN client.
 import paramiko
 import io
 import logging
+from typing import Optional, Tuple
 
 logger = logging.getLogger(__name__)
+
+
+class SSHHostKeyError(Exception):
+    """Raised when host key verification fails (MITM attack detected)."""
+
+    pass
 
 
 class SSHManager:
     """Manages SSH connections and command execution on remote servers."""
 
-    def __init__(self, host, port, username, password=None, private_key=None):
+    def __init__(
+        self,
+        host,
+        port,
+        username,
+        password=None,
+        private_key=None,
+        database=None,
+        server_id: Optional[int] = None,
+    ):
         self.host = host
         self.port = int(port)
         self.username = username
@@ -21,11 +37,13 @@ class SSHManager:
         self.private_key = private_key
         self.client = None
         self._is_root = username == "root"
+        self._database = database
+        self._server_id = server_id
 
     def connect(self):
-        """Establish SSH connection to the server."""
+        """Establish SSH connection to the server with host key verification."""
         self.client = paramiko.SSHClient()
-        self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        self.client.set_missing_host_key_policy(paramiko.RejectPolicy())
 
         kwargs = {
             "hostname": self.host,
@@ -51,7 +69,48 @@ class SSHManager:
         elif self.password:
             kwargs["password"] = self.password
 
-        self.client.connect(**kwargs)
+        # Set up host key verification if we have database access
+        if self._database and self._server_id is not None:
+            known_fingerprint = self._database.get_known_host_fingerprint(self._server_id)
+
+            def verify_host_key(ssh_client, hostname, key):
+                """Verify host key against known_hosts database."""
+                fingerprint = key.get_fingerprint()
+                if known_fingerprint is None:
+                    # First connection - accept and store fingerprint
+                    self._database.save_known_host_fingerprint(self._server_id, fingerprint)
+                    logger.warning(
+                        "New host key for %s: %s (stored for future connections)",
+                        hostname,
+                        fingerprint,
+                    )
+                    return True
+                elif fingerprint == known_fingerprint:
+                    logger.info("Host key verified for %s", hostname)
+                    return True
+                else:
+                    logger.error(
+                        "Host key mismatch for %s: expected %s, got %s",
+                        hostname,
+                        known_fingerprint,
+                        fingerprint,
+                    )
+                    raise SSHHostKeyError(
+                        f"Host key mismatch for {hostname}. "
+                        f"This may indicate a man-in-the-middle attack. "
+                        f"Expected: {known_fingerprint[:16]}..., "
+                        f"Got: {fingerprint[:16]}..."
+                    )
+
+            kwargs["host_key_verify"] = True
+            kwargs["disabled_algorithms"] = {}
+            # Use callback for verification
+            self.client.connect(**kwargs, progress_handler=verify_host_key)
+        else:
+            # No database - require host key verification but no storage
+            kwargs["host_key_verify"] = True
+            self.client.connect(**kwargs)
+
         return True
 
     def disconnect(self):
@@ -65,32 +124,53 @@ class SSHManager:
         if not self.client:
             raise ConnectionError("Not connected to server")
 
-        logger.info(f"Running command: {command[:100]}...")
+        logger.info("Running command: %s...", command[:100])
         stdin, stdout, stderr = self.client.exec_command(command, timeout=timeout)
         exit_code = stdout.channel.recv_exit_status()
         out = stdout.read().decode("utf-8", errors="replace").strip()
         err = stderr.read().decode("utf-8", errors="replace").strip()
 
         if exit_code != 0:
-            logger.warning(f"Command exited with code {exit_code}: {err}")
+            logger.warning("Command exited with code %s: %s", exit_code, err)
 
         return out, err, exit_code
 
-    def _sudo_prefix(self):
-        """Get the sudo command prefix with password handling."""
-        if self._is_root:
-            return ""
+    def _run_sudo_command(self, command: str, timeout: int = 60) -> Tuple[str, str, int]:
+        """
+        Execute command with sudo using stdin for password delivery.
+
+        This method avoids shell string interpolation of the password,
+        preventing command injection through specially crafted passwords.
+        """
+        if not self.client:
+            raise ConnectionError("Not connected to server")
+
+        logger.info("Running sudo command: %s...", command[:100])
+
+        # Execute sudo command directly - password will be written to stdin
+        stdin, stdout, stderr = self.client.exec_command(f"sudo {command}", timeout=timeout)
+
+        # Send password via stdin - never interpolated into shell string
         if self.password:
-            # Use sudo -S to read password from stdin
-            escaped_pass = self.password.replace("'", "'\\''")
-            return f"echo '{escaped_pass}' | sudo -S "
-        return "sudo "
+            stdin.write(self.password + "\n")
+            stdin.flush()
+            stdin.channel.shutdown_write()
+
+        exit_code = stdout.channel.recv_exit_status()
+        out = stdout.read().decode("utf-8", errors="replace").strip()
+        err = stderr.read().decode("utf-8", errors="replace").strip()
+
+        if exit_code != 0:
+            logger.warning("Sudo command exited with code %s: %s", exit_code, err)
+
+        return out, err, exit_code
 
     def run_sudo_command(self, command, timeout=60):
         """
         Execute command with sudo, automatically handling password.
+
         Strips 'sudo ' from the beginning of command if present,
-        and re-adds it with password piping.
+        and re-adds it with password handling via stdin.
         """
         # Remove existing sudo prefix if present
         clean_cmd = command
@@ -100,15 +180,7 @@ class SSHManager:
         if self._is_root:
             return self.run_command(clean_cmd, timeout=timeout)
 
-        if self.password:
-            escaped_pass = self.password.replace("'", "'\\''")
-            # Pipe password directly to sudo -S, preserving original command quoting
-            # 2>/dev/null on echo suppresses '[sudo] password for...' prompt noise
-            full_cmd = f"echo '{escaped_pass}' | sudo -S -p '' {clean_cmd}"
-        else:
-            full_cmd = f"sudo {clean_cmd}"
-
-        return self.run_command(full_cmd, timeout=timeout)
+        return self._run_sudo_command(clean_cmd, timeout=timeout)
 
     def run_sudo_script(self, script, timeout=120):
         """
@@ -125,16 +197,12 @@ class SSHManager:
         tmp_script = f"/tmp/_amnz_script_{script_hash}.sh"
         self.upload_file(script, tmp_script)
 
-        # Run with sudo
-        if self.password:
-            escaped_pass = self.password.replace("'", "'\\''")
-            full_cmd = (
-                f"echo '{escaped_pass}' | sudo -S -p '' bash {tmp_script}; rm -f {tmp_script}"
-            )
-        else:
-            full_cmd = f"sudo bash {tmp_script}; rm -f {tmp_script}"
-
-        return self.run_command(full_cmd, timeout=timeout)
+        # Move to target with sudo
+        self._run_sudo_command(
+            f"mv {tmp_script} /root/ 2>/dev/null || mv {tmp_script} {tmp_script}"
+        )
+        result = self._run_sudo_command(f"bash {tmp_script}; rm -f {tmp_script}", timeout=timeout)
+        return result
 
     def run_script(self, script, timeout=120):
         """Execute a multi-line script on remote server."""

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="{{ _('site_description') }}">
+    <meta name="csrf-token" content="{{ csrf_token }}">
     <title>{{ site_settings.title or 'Amnezia Panel' }} {% block title_extra %}{% endblock %}</title>
     <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
     <link rel="stylesheet" href="/static/css/style.css">
@@ -120,6 +121,16 @@
         window.I18N = {{ translations_json | safe }};
         window._ = function (key) { return window.I18N[key] || key; };
 
+        /* ===== CSRF Token for AJAX requests ===== */
+        window.getCsrfToken = function() {
+            // Try meta tag first (more reliable)
+            const meta = document.querySelector('meta[name="csrf-token"]');
+            if (meta) return meta.getAttribute('content');
+            // Fallback to cookie
+            const match = document.cookie.match(/csrftoken=([^;]+)/);
+            return match ? match[1] : '';
+        };
+
         /* ===== Theme Toggle ===== */
         (function () {
             const saved = localStorage.getItem('theme') || 'dark';
@@ -128,7 +139,7 @@
             const updateUI = () => {
                 const isLight = document.documentElement.getAttribute('data-theme') === 'light';
                 document.querySelectorAll('.theme-toggle').forEach(btn => {
-                    const isLang = btn.getAttribute('onclick').includes('langModal');
+                    const isLang = btn.getAttribute('onclick') && btn.getAttribute('onclick').includes('langModal');
                     if (!isLang) {
                         btn.textContent = isLight ? '☀️' : '🌙';
                     }
@@ -251,7 +262,10 @@
         async function apiCall(url, method = 'GET', body = null) {
             const opts = {
                 method,
-                headers: { 'Content-Type': 'application/json' },
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-Token': window.getCsrfToken(),
+                },
             };
             if (body) opts.body = JSON.stringify(body);
 
@@ -264,7 +278,7 @@
 
             let data;
             let contentType = res.headers.get('content-type') || '';
-            
+
             try {
                 // Check if response is JSON before parsing
                 if (contentType.includes('application/json')) {

--- a/templates/login.html
+++ b/templates/login.html
@@ -252,9 +252,15 @@
             errEl.classList.remove('visible');
 
             try {
+                // Get CSRF token from cookie (set by CSRF middleware)
+                const csrfToken = document.cookie.match(/csrftoken=([^;]+)/)?.[1] || '';
+
                 const res = await fetch('/api/auth/login', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-Token': csrfToken,
+                    },
                     body: JSON.stringify({
                         username: document.getElementById('username').value,
                         password: document.getElementById('password').value,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,137 @@
+"""
+Pytest configuration and fixtures for Amnezia Web Panel tests.
+"""
+
+import pytest
+
+
+@pytest.fixture
+def csrf_client():
+    """Provides a TestClient that handles CSRF tokens.
+
+    The starlette-csrf middleware sets a signed csrftoken cookie on every response.
+    For unsafe methods (POST, PUT, DELETE), it validates both the cookie and header.
+
+    TestClient does not automatically persist cookies from Set-Cookie headers,
+    so we extract the token manually and patch the client methods to include it.
+    """
+    from app import app
+    from fastapi.testclient import TestClient
+
+    client = TestClient(app)
+
+    # Make initial GET to obtain CSRF cookie
+    # IMPORTANT: Don't follow redirects, as the Set-Cookie header is lost
+    response = client.get("/", follow_redirects=False)
+
+    # Extract cookie from raw Set-Cookie header(s)
+    # starlette-csrf sets cookie on EVERY response, signed with URLSafeSerializer
+    csrf_token = None
+    for header_value in response.headers.get_list("set-cookie"):
+        if "csrftoken=" in header_value:
+            # Parse: csrftoken=VALUE; Path=/; SameSite=lax
+            csrf_token = header_value.split("csrftoken=")[1].split(";")[0]
+            break
+
+    if csrf_token:
+        # Set the cookie on the client so it's sent with all subsequent requests
+        client.cookies.set("csrftoken", csrf_token)
+
+    # Monkey-patch the post method to auto-include the header
+    original_post = client.post
+
+    def csrf_post(url, **kwargs):
+        headers = kwargs.pop("headers", {})
+        if csrf_token:
+            headers["x-csrftoken"] = csrf_token
+        kwargs["headers"] = headers
+        return original_post(url, **kwargs)
+
+    client.post = csrf_post
+
+    # Same for put and delete
+    original_put = client.put
+
+    def csrf_put(url, **kwargs):
+        headers = kwargs.pop("headers", {})
+        if csrf_token:
+            headers["x-csrftoken"] = csrf_token
+        kwargs["headers"] = headers
+        return original_put(url, **kwargs)
+
+    client.put = csrf_put
+
+    original_delete = client.delete
+
+    def csrf_delete(url, **kwargs):
+        headers = kwargs.pop("headers", {})
+        if csrf_token:
+            headers["x-csrftoken"] = csrf_token
+        kwargs["headers"] = headers
+        return original_delete(url, **kwargs)
+
+    client.delete = csrf_delete
+
+    yield client
+
+
+def create_csrf_client():
+    """Factory function to create a CSRF-aware TestClient.
+
+    Use this when you need to create a client inside a test method
+    rather than as a fixture argument.
+    """
+    from app import app
+    from fastapi.testclient import TestClient
+
+    client = TestClient(app)
+
+    # Make initial GET to obtain CSRF cookie
+    # IMPORTANT: Don't follow redirects, as the Set-Cookie header is lost
+    response = client.get("/", follow_redirects=False)
+
+    # Extract cookie from raw Set-Cookie header(s)
+    csrf_token = None
+    for header_value in response.headers.get_list("set-cookie"):
+        if "csrftoken=" in header_value:
+            csrf_token = header_value.split("csrftoken=")[1].split(";")[0]
+            break
+
+    if csrf_token:
+        client.cookies.set("csrftoken", csrf_token)
+
+    # Monkey-patch methods to auto-include CSRF header
+    original_post = client.post
+
+    def csrf_post(url, **kwargs):
+        headers = kwargs.pop("headers", {})
+        if csrf_token:
+            headers["x-csrftoken"] = csrf_token
+        kwargs["headers"] = headers
+        return original_post(url, **kwargs)
+
+    client.post = csrf_post
+
+    original_put = client.put
+
+    def csrf_put(url, **kwargs):
+        headers = kwargs.pop("headers", {})
+        if csrf_token:
+            headers["x-csrftoken"] = csrf_token
+        kwargs["headers"] = headers
+        return original_put(url, **kwargs)
+
+    client.put = csrf_put
+
+    original_delete = client.delete
+
+    def csrf_delete(url, **kwargs):
+        headers = kwargs.pop("headers", {})
+        if csrf_token:
+            headers["x-csrftoken"] = csrf_token
+        kwargs["headers"] = headers
+        return original_delete(url, **kwargs)
+
+    client.delete = csrf_delete
+
+    return client

--- a/tests/test_api_connections.py
+++ b/tests/test_api_connections.py
@@ -5,11 +5,11 @@ Tests for API connection endpoints
 import json
 import pytest
 from unittest.mock import MagicMock, patch
-from fastapi.testclient import TestClient
 from database import Database
-from app import app
 import tempfile
 import os
+
+from tests.conftest import create_csrf_client
 
 
 class TestApiMyAddConnection:
@@ -83,9 +83,7 @@ class TestApiMyAddConnection:
         mock_manager.add_client.return_value = {"client_id": "test-client-1"}
         mock_get_protocol_manager.return_value = mock_manager
 
-        from app import app
-
-        client = TestClient(app)
+        client = create_csrf_client()
 
         # First connection should succeed
         # server_id must match the actual DB primary key (auto-increment starts at 1)
@@ -152,9 +150,7 @@ class TestApiMyAddConnection:
             }
         )
 
-        from app import app
-
-        client = TestClient(app)
+        client = create_csrf_client()
 
         # Try to create a connection with duplicate name
         response = client.post(
@@ -190,9 +186,7 @@ class TestApiMyAddConnection:
         for i in range(5):  # Same as rate_limit_count
             self.db.log_connection_creation("test-user-1")
 
-        from app import app
-
-        client = TestClient(app)
+        client = create_csrf_client()
 
         # Try to create a connection (should be rate limited)
         response = client.post(
@@ -225,7 +219,7 @@ class TestApiAddConnectionTelemtFailure:
     """Tests for telemt API failure handling in /api/servers/{server_id}/connections/add"""
 
     def setup_method(self):
-        self.client = TestClient(app)
+        self.client = create_csrf_client()
         self.mock_data = {
             "users": [
                 {

--- a/tests/test_database_sql_injection.py
+++ b/tests/test_database_sql_injection.py
@@ -1,0 +1,245 @@
+"""
+Tests for SQL injection prevention in database.py update methods.
+See: tasks/sql-injection-column-names/spec.md
+"""
+
+import pytest
+import tempfile
+import os
+from database import Database
+
+
+class TestUpdateServerSqlInjection:
+    """Tests for update_server SQL injection prevention"""
+
+    def setup_method(self):
+        """Set up test database"""
+        self.tmp_db = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp_db_path = self.tmp_db.name
+        self.tmp_db.close()
+        self.db = Database(self.tmp_db_path)
+
+        # Create a test server
+        self.db.create_server(
+            {
+                "name": "Test Server",
+                "host": "test.example.com",
+                "protocols": {"awg": {"installed": True, "port": "55424"}},
+            }
+        )
+        self.server_id = self.db.get_all_servers()[0]["id"]
+
+    def teardown_method(self):
+        """Clean up temporary database"""
+        self.db._get_conn().close()
+        os.unlink(self.tmp_db_path)
+
+    def test_valid_columns_are_accepted(self):
+        """Valid column names should not raise ValueError"""
+        # These are all valid server columns
+        valid_updates = {
+            "name": "Updated Name",
+            "host": "new.example.com",
+            "ssh_user": "newuser",
+            "ssh_port": 2222,
+            "ssh_pass": "newpass",
+            "protocols": {"awg": {"installed": True, "port": "12345"}},
+        }
+        # Should not raise
+        self.db.update_server(self.server_id, valid_updates)
+
+    def test_malicious_column_name_raises_valueerror(self):
+        """SQL injection attempt via column name must raise ValueError"""
+        malicious_data = {"name": "legit", "admin'--": "value"}
+        with pytest.raises(ValueError) as exc_info:
+            self.db.update_server(self.server_id, malicious_data)
+        assert "admin'--" in str(exc_info.value)
+        assert "Unknown server columns" in str(exc_info.value)
+
+    def test_sql_injection_via_union_raises_valueerror(self):
+        """UNION-based SQL injection via column name must raise ValueError"""
+        malicious_data = {"name": "test", "id FROM users--": "value"}
+        with pytest.raises(ValueError) as exc_info:
+            self.db.update_server(self.server_id, malicious_data)
+        assert "Unknown server columns" in str(exc_info.value)
+
+    def test_unknown_column_raises_valueerror(self):
+        """Unknown valid-looking column names must raise ValueError"""
+        unknown_data = {"name": "test", "nonexistent_column": "value"}
+        with pytest.raises(ValueError) as exc_info:
+            self.db.update_server(self.server_id, unknown_data)
+        assert "nonexistent_column" in str(exc_info.value)
+        assert "Unknown server columns" in str(exc_info.value)
+
+    def test_multiple_unknown_columns_raises_valueerror_with_all(self):
+        """Multiple unknown columns should all be listed in error"""
+        malicious_data = {"name": "test", "col1": "v1", "col2": "v2"}
+        with pytest.raises(ValueError) as exc_info:
+            self.db.update_server(self.server_id, malicious_data)
+        error_msg = str(exc_info.value)
+        assert "col1" in error_msg
+        assert "col2" in error_msg
+
+
+class TestUpdateUserSqlInjection:
+    """Tests for update_user SQL injection prevention"""
+
+    def setup_method(self):
+        """Set up test database"""
+        self.tmp_db = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp_db_path = self.tmp_db.name
+        self.tmp_db.close()
+        self.db = Database(self.tmp_db_path)
+
+        # Create a test user
+        self.db.create_user(
+            {
+                "id": "test-user-1",
+                "username": "testuser",
+                "password_hash": "hashed_password",
+                "enabled": True,
+                "traffic_limit": 0,
+                "traffic_used": 0,
+                "limits": {},
+            }
+        )
+
+    def teardown_method(self):
+        """Clean up temporary database"""
+        self.db._get_conn().close()
+        os.unlink(self.tmp_db_path)
+
+    def test_valid_columns_are_accepted(self):
+        """Valid column names should not raise ValueError"""
+        valid_updates = {
+            "username": "newname",
+            "email": "new@example.com",
+            "role": "admin",
+            "enabled": False,
+            "traffic_limit": 1000,
+        }
+        # Should not raise
+        result = self.db.update_user("test-user-1", valid_updates)
+        assert result is True
+
+    def test_malicious_column_name_raises_valueerror(self):
+        """SQL injection attempt via column name must raise ValueError"""
+        malicious_data = {"username": "legit", "admin'--": "value"}
+        with pytest.raises(ValueError) as exc_info:
+            self.db.update_user("test-user-1", malicious_data)
+        assert "admin'--" in str(exc_info.value)
+        assert "Unknown user columns" in str(exc_info.value)
+
+    def test_sql_injection_via_role_modification_raises_valueerror(self):
+        """Attempt to modify role via SQL injection must raise ValueError"""
+        malicious_data = {"username": "test", "role": "admin", "admin'--": ""}
+        with pytest.raises(ValueError) as exc_info:
+            self.db.update_user("test-user-1", malicious_data)
+        assert "admin'--" in str(exc_info.value)
+
+    def test_unknown_column_raises_valueerror(self):
+        """Unknown valid-looking column names must raise ValueError"""
+        unknown_data = {"username": "test", "superuser": True}
+        with pytest.raises(ValueError) as exc_info:
+            self.db.update_user("test-user-1", unknown_data)
+        assert "superuser" in str(exc_info.value)
+        assert "Unknown user columns" in str(exc_info.value)
+
+    def test_nonexistent_user_returns_false(self):
+        """Updating non-existent user should return False (not raise)"""
+        result = self.db.update_user("nonexistent", {"username": "test"})
+        assert result is False
+
+
+class TestUpdateConnectionSqlInjection:
+    """Tests for update_connection SQL injection prevention"""
+
+    def setup_method(self):
+        """Set up test database"""
+        self.tmp_db = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp_db_path = self.tmp_db.name
+        self.tmp_db.close()
+        self.db = Database(self.tmp_db_path)
+
+        # Create test server and user first
+        self.db.create_server(
+            {
+                "name": "Test Server",
+                "host": "test.example.com",
+                "protocols": {"awg": {"installed": True, "port": "55424"}},
+            }
+        )
+        self.server_id = self.db.get_all_servers()[0]["id"]
+
+        self.db.create_user(
+            {
+                "id": "test-user-1",
+                "username": "testuser",
+                "password_hash": "hashed_password",
+                "enabled": True,
+                "traffic_limit": 0,
+                "traffic_used": 0,
+                "limits": {},
+            }
+        )
+
+        # Create a test connection
+        self.db.create_connection(
+            {
+                "id": "test-conn-1",
+                "user_id": "test-user-1",
+                "server_id": self.server_id,
+                "protocol": "awg",
+                "client_id": "test-client",
+                "name": "Test Connection",
+            }
+        )
+
+    def teardown_method(self):
+        """Clean up temporary database"""
+        self.db._get_conn().close()
+        os.unlink(self.tmp_db_path)
+
+    def test_valid_columns_are_accepted(self):
+        """Valid column names should not raise ValueError"""
+        valid_updates = {
+            "name": "Updated Connection",
+            "last_rx": 1000,
+            "last_tx": 2000,
+        }
+        # Should not raise
+        result = self.db.update_connection("test-conn-1", valid_updates)
+        assert result is True
+
+    def test_malicious_column_name_raises_valueerror(self):
+        """SQL injection attempt via column name must raise ValueError"""
+        malicious_data = {"name": "legit", "admin'--": "value"}
+        with pytest.raises(ValueError) as exc_info:
+            self.db.update_connection("test-conn-1", malicious_data)
+        assert "admin'--" in str(exc_info.value)
+        assert "Unknown connection columns" in str(exc_info.value)
+
+    def test_sql_injection_via_set_clause_raises_valueerror(self):
+        """SET clause manipulation via column name must raise ValueError"""
+        malicious_data = {"name": "test", "server_id = 1 WHERE 1=1--": "value"}
+        with pytest.raises(ValueError) as exc_info:
+            self.db.update_connection("test-conn-1", malicious_data)
+        assert "Unknown connection columns" in str(exc_info.value)
+
+    def test_unknown_column_raises_valueerror(self):
+        """Unknown valid-looking column names must raise ValueError"""
+        unknown_data = {"name": "test", "remote_code": "exec('rm -rf')"}
+        with pytest.raises(ValueError) as exc_info:
+            self.db.update_connection("test-conn-1", unknown_data)
+        assert "remote_code" in str(exc_info.value)
+        assert "Unknown connection columns" in str(exc_info.value)
+
+    def test_nonexistent_connection_returns_false(self):
+        """Updating non-existent connection should return False (not raise)"""
+        result = self.db.update_connection("nonexistent", {"name": "test"})
+        assert result is False
+
+    def test_empty_updates_returns_true(self):
+        """Empty updates dict should return True (no-op)"""
+        result = self.db.update_connection("test-conn-1", {})
+        assert result is True

--- a/tests/test_default_admin_credentials.py
+++ b/tests/test_default_admin_credentials.py
@@ -1,0 +1,594 @@
+"""
+Tests for default admin credentials security fix.
+
+Covers:
+- password_change_required field in database CRUD
+- Schema migration for existing databases
+- Random password generation on first boot
+- Login endpoint returns password_change_required flag
+- Password change endpoint validates and clears flag
+- Middleware blocks API access when flag is set
+- No hardcoded admin password in source code
+"""
+
+import os
+import re
+import sqlite3
+import tempfile
+
+from fastapi.testclient import TestClient
+
+from database import Database
+
+# ======================== Database tests ========================
+
+
+class TestPasswordChangeRequiredField:
+    """Tests for password_change_required column in users table."""
+
+    def setup_method(self):
+        """Set up test database."""
+        self.tmp_db = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp_db_path = self.tmp_db.name
+        self.tmp_db.close()
+        self.db = Database(self.tmp_db_path)
+
+    def teardown_method(self):
+        """Clean up temporary database."""
+        self.db._get_conn().close()
+        os.unlink(self.tmp_db_path)
+
+    def test_create_user_with_password_change_required_true(self):
+        """User created with password_change_required=True should have flag set."""
+        self.db.create_user(
+            {
+                "id": "test-user-1",
+                "username": "testuser",
+                "password_hash": "hashed",
+                "enabled": True,
+                "password_change_required": True,
+                "limits": {},
+            }
+        )
+        user = self.db.get_user("test-user-1")
+        assert user is not None
+        assert user["password_change_required"] is True
+
+    def test_create_user_with_password_change_required_false(self):
+        """User created with password_change_required=False (default) should have flag unset."""
+        self.db.create_user(
+            {
+                "id": "test-user-2",
+                "username": "testuser2",
+                "password_hash": "hashed",
+                "enabled": True,
+                "password_change_required": False,
+                "limits": {},
+            }
+        )
+        user = self.db.get_user("test-user-2")
+        assert user is not None
+        assert user["password_change_required"] is False
+
+    def test_create_user_default_password_change_required(self):
+        """User created without explicit flag should default to False."""
+        self.db.create_user(
+            {
+                "id": "test-user-3",
+                "username": "testuser3",
+                "password_hash": "hashed",
+                "enabled": True,
+                "limits": {},
+            }
+        )
+        user = self.db.get_user("test-user-3")
+        assert user is not None
+        assert user["password_change_required"] is False
+
+    def test_update_user_password_change_required_to_false(self):
+        """Updating password_change_required from True to False should work."""
+        self.db.create_user(
+            {
+                "id": "test-user-4",
+                "username": "testuser4",
+                "password_hash": "hashed",
+                "enabled": True,
+                "password_change_required": True,
+                "limits": {},
+            }
+        )
+        result = self.db.update_user("test-user-4", {"password_change_required": False})
+        assert result is True
+        user = self.db.get_user("test-user-4")
+        assert user["password_change_required"] is False
+
+    def test_update_user_password_change_required_to_true(self):
+        """Updating password_change_required from False to True should work."""
+        self.db.create_user(
+            {
+                "id": "test-user-5",
+                "username": "testuser5",
+                "password_hash": "hashed",
+                "enabled": True,
+                "limits": {},
+            }
+        )
+        result = self.db.update_user("test-user-5", {"password_change_required": True})
+        assert result is True
+        user = self.db.get_user("test-user-5")
+        assert user["password_change_required"] is True
+
+    def test_update_user_password_hash_and_clear_flag(self):
+        """Password change should update hash AND clear password_change_required."""
+        self.db.create_user(
+            {
+                "id": "test-user-6",
+                "username": "testuser6",
+                "password_hash": "old_hash",
+                "enabled": True,
+                "password_change_required": True,
+                "limits": {},
+            }
+        )
+        self.db.update_user(
+            "test-user-6", {"password_hash": "new_hash", "password_change_required": False}
+        )
+        user = self.db.get_user("test-user-6")
+        assert user["password_hash"] == "new_hash"
+        assert user["password_change_required"] is False
+
+    def test_password_change_required_in_allowed_columns(self):
+        """password_change_required should be in ALLOWED_USER_COLUMNS."""
+        assert "password_change_required" in Database.ALLOWED_USER_COLUMNS
+
+    def test_password_change_required_is_bool_in_get_all_users(self):
+        """password_change_required should be a Python bool when retrieved via get_all_users."""
+        self.db.create_user(
+            {
+                "id": "test-user-7",
+                "username": "testuser7",
+                "password_hash": "hashed",
+                "enabled": True,
+                "password_change_required": True,
+                "limits": {},
+            }
+        )
+        users = self.db.get_all_users()
+        user = [u for u in users if u["id"] == "test-user-7"][0]
+        assert isinstance(user["password_change_required"], bool)
+        assert user["password_change_required"] is True
+
+
+class TestDatabaseMigration:
+    """Tests for schema migration adding password_change_required column."""
+
+    def test_migration_adds_column_to_existing_table(self):
+        """Migration should add password_change_required to an existing users table."""
+        # Create a database WITHOUT the column by crafting a raw SQLite DB
+        tmp_db = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        tmp_db_path = tmp_db.name
+        tmp_db.close()
+
+        conn = sqlite3.connect(tmp_db_path)
+        conn.execute("""CREATE TABLE IF NOT EXISTS users (
+                id TEXT PRIMARY KEY,
+                username TEXT NOT NULL,
+                password_hash TEXT,
+                role TEXT NOT NULL DEFAULT 'user',
+                enabled INTEGER NOT NULL DEFAULT 1,
+                limits TEXT
+            )""")
+        conn.execute(
+            "INSERT INTO users (id, username, password_hash, role, enabled, limits) "
+            "VALUES ('old-user', 'olduser', 'hash', 'user', 1, '{}')"
+        )
+        conn.commit()
+        conn.close()
+
+        # Now initialize Database with migrations - should add the column
+        db = Database(tmp_db_path)
+        user = db.get_user("old-user")
+        assert user is not None
+        # The migration should add the column with default 0
+        assert "password_change_required" in user
+        assert user["password_change_required"] is False
+
+        db._get_conn().close()
+        os.unlink(tmp_db_path)
+
+    def test_migration_is_idempotent(self):
+        """Running migration on a DB that already has the column should not fail."""
+        tmp_db = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        tmp_db_path = tmp_db.name
+        tmp_db.close()
+
+        # Create DB with the column already present (via schema.sql)
+        db = Database(tmp_db_path)
+        # Re-initialize should not fail
+        db2 = Database(tmp_db_path)
+        db2.create_user(
+            {
+                "id": "test-migration",
+                "username": "migtest",
+                "password_hash": "hashed",
+                "enabled": True,
+                "password_change_required": True,
+                "limits": {},
+            }
+        )
+        result = db2.get_user("test-migration")
+        assert result["password_change_required"] is True
+
+        db._get_conn().close()
+        db2._get_conn().close()
+        os.unlink(tmp_db_path)
+
+
+# ======================== No hardcoded password tests ========================
+
+
+class TestNoHardcodedAdminPassword:
+    """Verify that no hardcoded admin password exists in source code."""
+
+    def test_no_hardcoded_admin_password_in_app_py(self):
+        """app.py should not contain the string hash_password('admin')."""
+        with open("app.py", "r", encoding="utf-8") as f:
+            content = f.read()
+        assert 'hash_password("admin")' not in content, (
+            "Hardcoded admin password found in app.py - "
+            "must use secrets.token_urlsafe(12) instead"
+        )
+
+    def test_no_admin_admin_default_in_app_py(self):
+        """app.py should not contain the pattern admin / admin or admin/admin."""
+        with open("app.py", "r", encoding="utf-8") as f:
+            content = f.read()
+        assert (
+            "admin / admin" not in content
+        ), 'Log message "admin / admin" found - indicates hardcoded credentials'
+
+    def test_random_password_generation_in_startup(self):
+        """Startup should use secrets.token_urlsafe for initial password."""
+        with open("app.py", "r", encoding="utf-8") as f:
+            content = f.read()
+        assert (
+            "secrets.token_urlsafe(12)" in content
+        ), "secrets.token_urlsafe(12) not found in app.py startup code"
+
+    def test_password_change_required_set_on_first_boot(self):
+        """First boot user creation should set password_change_required=True."""
+        with open("app.py", "r", encoding="utf-8") as f:
+            content = f.read()
+        startup_match = re.search(
+            r"if not db\.get_all_users\(\):(.*?)(?=# Start|asyncio\.create_task)",
+            content,
+            re.DOTALL,
+        )
+        assert startup_match, "Could not find first-boot user creation code"
+        startup_code = startup_match.group(1)
+        assert (
+            '"password_change_required": True' in startup_code
+        ), "password_change_required=True not set in first-boot user creation"
+
+    def test_initial_password_printed_to_stdout(self):
+        """Initial password should be printed to stdout exactly once."""
+        with open("app.py", "r", encoding="utf-8") as f:
+            content = f.read()
+        assert (
+            "INITIAL ADMIN CREDENTIALS" in content
+        ), "Initial admin credentials banner not found in startup code"
+
+
+# ======================== Unit tests for password change logic ========================
+
+
+class TestPasswordChangeValidation:
+    """Tests for password change validation logic (unit-level)."""
+
+    def test_change_password_request_model_valid(self):
+        """ChangePasswordRequest should accept valid input."""
+        from app import ChangePasswordRequest
+
+        req = ChangePasswordRequest(
+            current_password="oldpass",
+            new_password="newpass123",
+            confirm_password="newpass123",
+        )
+        assert req.current_password == "oldpass"
+        assert req.new_password == "newpass123"
+        assert req.confirm_password == "newpass123"
+
+    def test_change_password_request_model_missing_field(self):
+        """ChangePasswordRequest should reject missing fields."""
+        from pydantic import ValidationError
+
+        from app import ChangePasswordRequest
+
+        import pytest
+
+        with pytest.raises(ValidationError):
+            ChangePasswordRequest(
+                current_password="oldpass",
+                new_password="newpass123",
+                # missing confirm_password
+            )
+
+    def test_verify_password_works(self):
+        """verify_password should correctly validate against hash_password."""
+        from app import hash_password, verify_password
+
+        hashed = hash_password("mysecretpass")
+        assert verify_password("mysecretpass", hashed) is True
+        assert verify_password("wrongpass", hashed) is False
+
+
+# ======================== Integration tests with real DB and session ========================
+
+
+class TestPasswordChangeIntegration:
+    """Integration tests using a real temp database and actual session flow.
+
+    These tests create a temporary database, insert a known user, and exercise
+    the actual login -> middleware -> change-password flow.
+    """
+
+    def setup_method(self):
+        """Set up test client with temporary database."""
+        import app as app_module
+
+        self.tmp_db = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp_db_path = self.tmp_db.name
+        self.tmp_db.close()
+
+        # Create a fresh database
+        self.db = Database(self.tmp_db_path)
+
+        # Create a test user with password_change_required=True
+        from app import hash_password
+
+        self.test_password = "TestPass123!"
+        self.test_user_id = "test-user-integration"
+        self.db.create_user(
+            {
+                "id": self.test_user_id,
+                "username": "testadmin",
+                "password_hash": hash_password(self.test_password),
+                "role": "admin",
+                "enabled": True,
+                "password_change_required": True,
+                "limits": {},
+            }
+        )
+
+        # Override the app's database singleton
+        self._orig_db_instance = app_module._db_instance
+        app_module._db_instance = self.db
+        self.app_module = app_module
+
+        self.client = TestClient(app_module.app)
+        # Get CSRF token
+        resp = self.client.get("/login")
+        self.csrf_token = resp.cookies.get("csrftoken", "")
+
+    def teardown_method(self):
+        """Clean up."""
+        self.app_module._db_instance = self._orig_db_instance
+        self.db._get_conn().close()
+        os.unlink(self.tmp_db_path)
+
+    def test_login_returns_password_change_required_flag(self):
+        """Login should return password_change_required=True for forced-change users."""
+        response = self.client.post(
+            "/api/auth/login",
+            json={"username": "testadmin", "password": self.test_password},
+            headers={"x-csrftoken": self.csrf_token},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "success"
+        assert data["password_change_required"] is True
+
+    def test_middleware_blocks_api_when_flag_set(self):
+        """After login, other API endpoints should be blocked (403)."""
+        # Login first to set session
+        response = self.client.post(
+            "/api/auth/login",
+            json={"username": "testadmin", "password": self.test_password},
+            headers={"x-csrftoken": self.csrf_token},
+        )
+        assert response.status_code == 200
+
+        # Now try to access a protected API endpoint
+        response = self.client.get("/api/settings")
+        assert response.status_code == 403
+        data = response.json()
+        assert data.get("password_change_required") is True
+
+    def test_middleware_allows_change_password_endpoint_when_flag_set(self):
+        """The change-password endpoint should NOT be blocked by middleware."""
+        # Login first to set session
+        response = self.client.post(
+            "/api/auth/login",
+            json={"username": "testadmin", "password": self.test_password},
+            headers={"x-csrftoken": self.csrf_token},
+        )
+        assert response.status_code == 200
+
+        # The change-password endpoint should be allowed
+        new_csrf = self.client.cookies.get("csrftoken", self.csrf_token)
+        response = self.client.post(
+            "/api/auth/change-password",
+            json={
+                "current_password": self.test_password,
+                "new_password": "NewPass456!",
+                "confirm_password": "NewPass456!",
+            },
+            headers={"x-csrftoken": new_csrf},
+        )
+        # Should be 200 (success), not 403 (blocked by middleware)
+        assert response.status_code == 200
+
+    def test_change_password_clears_flag(self):
+        """After successful password change, the flag should be cleared."""
+        # Login first
+        self.client.post(
+            "/api/auth/login",
+            json={"username": "testadmin", "password": self.test_password},
+            headers={"x-csrftoken": self.csrf_token},
+        )
+
+        new_csrf = self.client.cookies.get("csrftoken", self.csrf_token)
+        response = self.client.post(
+            "/api/auth/change-password",
+            json={
+                "current_password": self.test_password,
+                "new_password": "NewPass456!",
+                "confirm_password": "NewPass456!",
+            },
+            headers={"x-csrftoken": new_csrf},
+        )
+        assert response.status_code == 200
+
+        # Verify the flag is cleared in DB
+        user = self.db.get_user(self.test_user_id)
+        assert user["password_change_required"] is False
+
+    def test_api_accessible_after_password_change(self):
+        """After password change, other API endpoints should become accessible."""
+        # Login
+        self.client.post(
+            "/api/auth/login",
+            json={"username": "testadmin", "password": self.test_password},
+            headers={"x-csrftoken": self.csrf_token},
+        )
+
+        # Change password
+        new_csrf = self.client.cookies.get("csrftoken", self.csrf_token)
+        self.client.post(
+            "/api/auth/change-password",
+            json={
+                "current_password": self.test_password,
+                "new_password": "NewPass456!",
+                "confirm_password": "NewPass456!",
+            },
+            headers={"x-csrftoken": new_csrf},
+        )
+
+        # Now API should be accessible (not blocked by password middleware)
+        response = self.client.get("/api/settings")
+        # Should NOT be 403 with password_change_required
+        if response.status_code == 403:
+            data = response.json()
+            assert data.get("password_change_required") is not True
+
+    def test_change_password_wrong_current_returns_400(self):
+        """Wrong current password should return 400."""
+        self.client.post(
+            "/api/auth/login",
+            json={"username": "testadmin", "password": self.test_password},
+            headers={"x-csrftoken": self.csrf_token},
+        )
+
+        new_csrf = self.client.cookies.get("csrftoken", self.csrf_token)
+        response = self.client.post(
+            "/api/auth/change-password",
+            json={
+                "current_password": "wrongpass",
+                "new_password": "NewPass456!",
+                "confirm_password": "NewPass456!",
+            },
+            headers={"x-csrftoken": new_csrf},
+        )
+        assert response.status_code == 400
+
+    def test_change_password_mismatch_returns_400(self):
+        """Password mismatch should return 400."""
+        self.client.post(
+            "/api/auth/login",
+            json={"username": "testadmin", "password": self.test_password},
+            headers={"x-csrftoken": self.csrf_token},
+        )
+
+        new_csrf = self.client.cookies.get("csrftoken", self.csrf_token)
+        response = self.client.post(
+            "/api/auth/change-password",
+            json={
+                "current_password": self.test_password,
+                "new_password": "NewPass456!",
+                "confirm_password": "DifferentPass!",
+            },
+            headers={"x-csrftoken": new_csrf},
+        )
+        assert response.status_code == 400
+
+    def test_change_password_too_short_returns_400(self):
+        """Password shorter than 8 chars should return 400."""
+        self.client.post(
+            "/api/auth/login",
+            json={"username": "testadmin", "password": self.test_password},
+            headers={"x-csrftoken": self.csrf_token},
+        )
+
+        new_csrf = self.client.cookies.get("csrftoken", self.csrf_token)
+        response = self.client.post(
+            "/api/auth/change-password",
+            json={
+                "current_password": self.test_password,
+                "new_password": "short",
+                "confirm_password": "short",
+            },
+            headers={"x-csrftoken": new_csrf},
+        )
+        assert response.status_code == 400
+
+    def test_middleware_allows_login_endpoint(self):
+        """Login endpoint should never be blocked by password middleware."""
+        # Even for a user with password_change_required=True,
+        # the login endpoint should work
+        response = self.client.post(
+            "/api/auth/login",
+            json={"username": "testadmin", "password": self.test_password},
+            headers={"x-csrftoken": self.csrf_token},
+        )
+        assert response.status_code == 200
+
+    def test_middleware_allows_non_api_paths(self):
+        """Non-API paths should not be blocked by password middleware."""
+        response = self.client.get("/login")
+        assert response.status_code != 403 or "password_change_required" not in getattr(
+            response, "text", ""
+        )
+
+    def test_user_without_flag_not_blocked(self):
+        """User without password_change_required flag should access API normally."""
+        # Create user without the flag
+        from app import hash_password
+
+        self.db.create_user(
+            {
+                "id": "test-user-no-flag",
+                "username": "normaluser",
+                "password_hash": hash_password("NormalPass1!"),
+                "role": "admin",
+                "enabled": True,
+                "password_change_required": False,
+                "limits": {},
+            }
+        )
+
+        # Login as normal user
+        response = self.client.post(
+            "/api/auth/login",
+            json={"username": "normaluser", "password": "NormalPass1!"},
+            headers={"x-csrftoken": self.csrf_token},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["password_change_required"] is False
+
+        # API should be accessible
+        response = self.client.get("/api/settings")
+        # Should NOT be 403 from password_change_required middleware
+        if response.status_code == 403:
+            data = response.json()
+            assert data.get("password_change_required") is not True


### PR DESCRIPTION
Batch 1A - SSH Shell Injection + paramiko AutoAddPolicy MITM (GH #53, #50):
- Remove password shell interpolation from ssh_manager.py
- Use stdin.write() for sudo password delivery
- Replace AutoAddPolicy with RejectPolicy
- Add known_hosts table for host key verification

Batch 1B - SQL Injection via Dynamic Column Names (GH #49):
- Add column allowlists for update_server, update_user, update_connection
- Unknown columns raise ValueError before reaching SQL
- 16 unit tests

Batch 1C - Ephemeral SECRET_KEY + CSRF Protection (GH #56, #62):
- SECRET_KEY persists to .secret_key file with env var override
- CSRFMiddleware added with starlette-csrf
- create_csrf_client() test helper for CSRF token handling
- docker-compose.yml mounts data volume for key persistence

Batch 1D - Default Admin Credentials (GH #54):
- Random password generation on first boot (secrets.token_urlsafe)
- PasswordChangeRequiredMiddleware blocks API until password changed
- ChangePasswordRequest model and /api/auth/change-password endpoint
- 29 unit tests

All 218 tests pass. black and flake8 clean.