### PR TITLE
fix: replace *** with proper Password translations

### DIFF
--- a/translations/en.json
+++ b/translations/en.json
@@ -55,7 +55,7 @@
     "info": "Info",
     "login_title": "Login to Panel",
     "username": "Username",
-    "password": "***",
+    "password": "Password",
     "captcha": "Captcha",
     "captcha_placeholder": "Enter characters from image",
     "captcha_hint": "Click to refresh image",

--- a/translations/fa.json
+++ b/translations/fa.json
@@ -55,7 +55,7 @@
     "info": "اطلاعات",
     "login_title": "ورود به پنل",
     "username": "نام کاربری",
-    "password": "***",
+    "password": "رمز عبور",
     "captcha": "کد امنیتی",
     "captcha_placeholder": "کاراکترهای تصویر را وارد کنید",
     "captcha_hint": "برای نوسازی تصویر کلیک کنید",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -55,7 +55,7 @@
     "info": "Info",
     "login_title": "Connexion au Panneau",
     "username": "Nom d'utilisateur",
-    "password": "***",
+    "password": "Mot de passe",
     "captcha": "Captcha",
     "captcha_placeholder": "Entrez les caractères",
     "captcha_hint": "Cliquez pour rafraîchir",

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -55,7 +55,7 @@
     "info": "Информация",
     "login_title": "Вход в панель",
     "username": "Логин",
-    "password": "***",
+    "password": "Пароль",
     "captcha": "Капча",
     "captcha_placeholder": "Введите символы с картинки",
     "captcha_hint": "Нажмите для обновления картинки",

--- a/translations/zh.json
+++ b/translations/zh.json
@@ -55,7 +55,7 @@
     "info": "信息",
     "login_title": "登录管理面板",
     "username": "用户名",
-    "password": "***",
+    "password": "密码",
     "captcha": "验证码",
     "captcha_placeholder": "输入图中字符",
     "captcha_hint": "点击刷新验证码",


### PR DESCRIPTION
The 'password' i18n key was set to '***' instead of the translated word for 'Password' in all 5 language files. This caused the login page label and the share password placeholder to display '***' instead of the proper label.

Changes:
- en.json: *** → Password
- ru.json: *** → Пароль
- fr.json: *** → Mot de passe
- zh.json: *** → 密码
- fa.json: *** → رمز عبور