### PR TITLE
fix: disable rate limiting for E2E tests (E2E_TESTING env var)

### DIFF
--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -463,3 +463,5 @@ dependencies.py            (project-root: auth dependencies)
 
 || [2026-04-27 16:55] | qa_bot | REVIEW_APPROVED | Task #45 (god-file-app-py): 637/637 tests pass, all 16 modules compile, 58 routes registered, no circular imports, no MEDIUM+ security findings, black/flake8 clean. APPROVED. |
 || [2026-04-27 17:05] | pm_bot | PROJECT_COMPLETED | Task #45 — God File Split — DONE-DONE. QA APPROVED, PR #108 MERGED to main. app.py reduced from 2777 to 280 lines (90% reduction). 14 new modules created. 637 tests pass. |
+
+[2026-04-27 17:45] | py_bot | IMPLEMENTATION_COMPLETE | E2E rate-limit fix: Added `enabled` parameter to slowapi Limiter based on E2E_TESTING env var in app/utils/rate_limiter.py. When E2E_TESTING=true, all @limiter.limit() decorators become no-ops. Added @pytest.mark.skipif on test_login_rate_limiting in tests/e2e/test_auth.py. 637/637 tests pass. black/flake8/py_compile clean. Branch: fix/e2e-rate-limit. |

--- a/app/utils/rate_limiter.py
+++ b/app/utils/rate_limiter.py
@@ -4,10 +4,17 @@ This module must be imported by both app.py and route modules
 so that @limiter.limit() decorators all register to the same instance.
 """
 
+import os
+
 from slowapi import Limiter
 
 from app.utils.helpers import _get_client_ip
 
+# When E2E_TESTING=true, disable rate limiting entirely so that
+# sequential E2E tests never hit 429s from budget exhaustion.
+# Rate limiting is still covered by unit tests (tests/test_rate_limiting.py).
+_rate_limiting_enabled = os.environ.get("E2E_TESTING", "").lower() != "true"
+
 # Single shared Limiter instance — all routers and the app must use this.
 # app.py will set app.state.limiter = limiter after creating the FastAPI app.
-limiter = Limiter(key_func=_get_client_ip)
+limiter = Limiter(key_func=_get_client_ip, enabled=_rate_limiting_enabled)

--- a/tests/e2e/test_auth.py
+++ b/tests/e2e/test_auth.py
@@ -1,5 +1,7 @@
 """E2E tests for authentication flows."""
 
+import os
+
 import pytest
 from playwright.sync_api import Page
 
@@ -89,6 +91,10 @@ def test_login_failure(page: Page, base_url: str) -> None:
 
 
 @pytest.mark.e2e
+@pytest.mark.skipif(
+    os.environ.get("E2E_TESTING", "").lower() == "true",
+    reason="Rate limiting disabled in E2E test mode",
+)
 def test_login_rate_limiting(page: Page, base_url: str) -> None:
     """Rapidly hit login with wrong creds 6 times → 429 on 6th attempt."""
     page.goto(f"{base_url}/login")


### PR DESCRIPTION
## What
Disable slowapi rate limiting when the  environment variable is set, preventing 429 errors during sequential E2E Playwright tests.

## Why
All E2E tests share the same client IP (127.0.0.1/X-Forwarded-For), so they share the same rate limit bucket. Earlier login attempts exhaust the 5/min budget, causing subsequent tests to get 429 "Слишком много запросов. Попробуйте позже." instead of expected responses.

## Technical approach
- slowapi's  constructor accepts an  parameter
- When ,  makes all  decorators no-ops
-  is skipped via  when rate limiting is disabled
- Production behavior unchanged (rate limiting active by default)

## Testing
- 637/637 unit tests pass
- 11/11 rate limiting unit tests pass (mock-based, not affected)
-  →  verified
- No env var →  (production) verified
- black/flake8/py_compile all clean

Files changed: 2 source files + 2 doc files