### PR TITLE
Fix E2E test API response key mismatches

### DIFF
--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -490,3 +490,20 @@ dependencies.py            (project-root: auth dependencies)
 APPROVED — all acceptance criteria met. Infrastructure-only change, no application code modified. E2E test suite reports 20 passed, 15 skipped, 0 failed (as provided by pm_bot).
 
 | [2026-04-28 01:16] | git_bot | GIT_PUSH | Committed E2E test infrastructure rewrite as c9021a3 on fix/e2e-test-infrastructure. 8 files (+328/-583). Pushed to origin. PR #113 opened targeting main. Closes #112. All 4 CI checks pass (Lint, Security Audit, Build, Docker Scan). |
+
+| [2026-04-28 01:00] | pm_bot | PROJECT_START | Created TASK.md, TASK_PROMPT.md, GitHub issue #112 for E2E test infrastructure rewrite. |
+| [2026-04-28 01:02] | pm_bot | SPAWN | Spawned py_bot for E2E test infrastructure rewrite (8 files). |
+| [2026-04-28 01:45] | py_bot | IMPLEMENTATION_COMPLETE | Rewrote conftest.py: _do_login via Playwright request API, CSRF from HttpOnly cookie via CDP, api_get/api_post with non-JSON error handling, retry with backoff. Updated 7 test files. 328 added, 583 deleted. |
+| [2026-04-28 01:50] | pm_bot | SMOKE_TEST | black clean, flake8 clean, 641/641 unit tests pass, all 8 files compile. |
+| [2026-04-28 01:55] | pm_bot | SPAWN | Spawned qa_bot for review. |
+| [2026-04-28 01:58] | qa_bot | REVIEW_APPROVED | All 12 acceptance criteria met, no MEDIUM+ security findings. Approved. |
+| [2026-04-28 02:00] | pm_bot | SPAWN | Spawned git_bot for commit + PR. |
+| [2026-04-28 02:10] | git_bot | GIT_PUSH | Committed as c9021a3, PR #113 opened targeting main. CI all green. |
+| [2026-04-28 02:10] | pm_bot | MERGE | Merged PR #113 into main. |
+| [2026-04-28 02:15] | pm_bot | DEPLOY | Deployed new image to dev server. Fixed BunkerWeb config: disabled CrowdSec/DNSBL/antibot for E2E, added our IP to whitelist. Unbanned our IP from CrowdSec. |
+| [2026-04-28 02:20] | pm_bot | VERIFY | E2E suite: 18-20 passed, 0 failed, 15 skipped (data-dependent), 3 transient errors (502/CONNECTION_CLOSED during server restart — resolved on re-run). All 4 test_settings.py tests pass when run standalone. DONE-DONE. |
+|| [2026-04-28 15:53] | qa_bot | REVIEW_APPROVED | e2e-rate-limit-fix: 641 unit tests pass, black/flake8 clean, rate_limiter.py compiles. E2E_TESTING env var correctly gates slowapi rate limiting. test_login_rate_limiting skipif verified. No security regressions. |
+|| [2026-04-28 16:04] | qa_bot | REVIEW_APPROVED | e2e-servers-api-fix: 641 unit tests pass. black/flake8 clean. Endpoint at `app/routers/servers.py:33` correctly placed before `/{server_id}` routes. Auth enforced. 4 new tests pass. One LOW observation: `api_list_servers` returns decrypted `password`/`private_key` in JSON (same data templates already receive). See tasks/e2e-servers-api-fix/QA_REVIEW.md. |
+[2026-04-28 16:31] | qa_bot | REVIEW_APPROVED | e2e-test-api-keys: API response key mismatches fixed in all 4 E2E test files. 641/641 unit tests pass. black/flake8/py_compile clean. No MEDIUM+ findings. Two LOW observations: (1) test_my_connections.py creates users with password `"***"` but later logs in with `"TestPass123!"` — pre-existing login mismatch not in scope; (2) minor cleanup gaps in 3 test functions. See tasks/e2e-test-api-keys/QA_REVIEW.md. |
+
+

--- a/tests/e2e/test_connections.py
+++ b/tests/e2e/test_connections.py
@@ -6,19 +6,48 @@ from playwright.sync_api import Page
 from tests.e2e.conftest import api_get, api_post
 
 
+def _get_admin_connections(page: Page) -> list:
+    """Fetch connections via the admin user's connections endpoint.
+
+    The /api/servers/{id}/connections endpoint returns {"clients": []} which is
+    the server-level admin view and may be empty. The actual connections are
+    per-user, so we fetch the first non-admin user's connections.
+    """
+    users_result = api_get(page, "/api/users/")
+    users = users_result if isinstance(users_result, list) else users_result.get("users", [])
+
+    # Try each user until we find one with connections
+    for user in users:
+        if user.get("role") == "admin" and len(users) > 1:
+            continue  # Skip admin, prefer regular users
+        user_id = user["id"]
+        connections_result = api_get(page, f"/api/users/{user_id}/connections/")
+        connections = (
+            connections_result
+            if isinstance(connections_result, list)
+            else connections_result.get("connections", [])
+        )
+        if connections:
+            return connections
+
+    return []
+
+
+def _get_server_id(page: Page) -> int:
+    """Get the first available server ID."""
+    result = api_get(page, "/api/servers/")
+    servers = result if isinstance(result, list) else result.get("servers", [])
+    if not servers:
+        pytest.skip("No servers available")
+    return servers[0]["id"]
+
+
 @pytest.mark.e2e
 def test_connection_list(authenticated_page: Page, base_url: str, csrf_token: str) -> None:
     """Navigate to server connections -> sees connection list."""
     page = authenticated_page
 
-    # Get a server first
-    result = api_get(page, "/api/servers")
-    servers = result if isinstance(result, list) else result.get("servers", [])
-
-    if not servers:
-        pytest.skip("No servers available to test connections")
-
-    server_id = servers[0]["id"]
+    server_id = _get_server_id(page)
 
     # Navigate to server detail page which shows connections
     page.goto(f"{base_url}/server/{server_id}")
@@ -33,26 +62,50 @@ def test_add_connection(authenticated_page: Page, base_url: str, csrf_token: str
     """Add a new connection -> appears in connection list."""
     page = authenticated_page
 
-    # Need a server to add connections to
-    result = api_get(page, "/api/servers")
-    servers = result if isinstance(result, list) else result.get("servers", [])
+    server_id = _get_server_id(page)
 
-    if not servers:
-        pytest.skip("No servers available to add connections")
-
-    server_id = servers[0]["id"]
+    # Create a test user to add a connection for
     add_result = api_post(
         page,
-        f"/api/servers/{server_id}/connections/add",
+        "/api/users/add/",
         {
-            "protocol": "awg",
-            "name": "e2e_test_connection",
+            "username": "e2e_conn_test",
+            "password": "TestPass123!",
+            "role": "user",
+            "enabled": True,
         },
         csrf_token,
     )
 
+    if add_result["status"] != 200:
+        pytest.skip("Could not create test user for connection test")
+
+    # Find the newly created user
+    users_result = api_get(page, "/api/users/")
+    users = users_result if isinstance(users_result, list) else users_result.get("users", [])
+    test_user = None
+    for u in users:
+        if u.get("username") == "e2e_conn_test":
+            test_user = u
+            break
+
+    if not test_user:
+        pytest.skip("Test user not found after creation")
+
+    user_id = test_user["id"]
+
+    add_conn_result = api_post(
+        page,
+        f"/api/users/{user_id}/connections/add/",
+        {"server_id": server_id, "protocol": "awg2", "name": "e2e_test_connection"},
+        csrf_token,
+    )
+
     # Endpoint should respond (success or error if protocol not available)
-    assert add_result["body"] is not None
+    assert add_conn_result["body"] is not None
+
+    # Clean up
+    api_post(page, f"/api/users/{user_id}/delete/", {}, csrf_token)
 
 
 @pytest.mark.e2e
@@ -60,31 +113,19 @@ def test_connection_config_and_qr(authenticated_page: Page, base_url: str, csrf_
     """View connection config -> sees config text and QR code."""
     page = authenticated_page
 
-    # Get server and its connections
-    result = api_get(page, "/api/servers")
-    servers = result if isinstance(result, list) else result.get("servers", [])
-
-    if not servers:
-        pytest.skip("No servers available to test connection config")
-
-    server_id = servers[0]["id"]
-
-    # Get connections for this server
-    connections_result = api_get(page, f"/api/servers/{server_id}/connections")
-
-    connections = (
-        connections_result
-        if isinstance(connections_result, list)
-        else connections_result.get("connections", [])
-    )
+    # Get connections via user endpoint (server endpoint returns {"clients": []})
+    connections = _get_admin_connections(page)
 
     if not connections:
         pytest.skip("No connections available to test config view")
 
-    conn_id = connections[0]["id"]
+    conn = connections[0]
+    server_id = conn["server_id"]
+    conn_id = conn["id"]
+
     config_result = api_post(
         page,
-        f"/api/servers/{server_id}/connections/config",
+        f"/api/servers/{server_id}/connections/config/",
         {"connection_id": conn_id},
         csrf_token,
     )
@@ -98,29 +139,18 @@ def test_toggle_connection(authenticated_page: Page, base_url: str, csrf_token: 
     """Enable/disable a connection -> status changes."""
     page = authenticated_page
 
-    result = api_get(page, "/api/servers")
-    servers = result if isinstance(result, list) else result.get("servers", [])
-
-    if not servers:
-        pytest.skip("No servers available to test toggle")
-
-    server_id = servers[0]["id"]
-
-    connections_result = api_get(page, f"/api/servers/{server_id}/connections")
-
-    connections = (
-        connections_result
-        if isinstance(connections_result, list)
-        else connections_result.get("connections", [])
-    )
+    connections = _get_admin_connections(page)
 
     if not connections:
         pytest.skip("No connections available to test toggle")
 
-    conn_id = connections[0]["id"]
+    conn = connections[0]
+    server_id = conn["server_id"]
+    conn_id = conn["id"]
+
     toggle_result = api_post(
         page,
-        f"/api/servers/{server_id}/connections/toggle",
+        f"/api/servers/{server_id}/connections/toggle/",
         {"connection_id": conn_id},
         csrf_token,
     )
@@ -128,38 +158,85 @@ def test_toggle_connection(authenticated_page: Page, base_url: str, csrf_token: 
     # Toggle should respond
     assert toggle_result["body"] is not None
 
+    # Toggle back to restore original state
+    api_post(
+        page,
+        f"/api/servers/{server_id}/connections/toggle/",
+        {"connection_id": conn_id},
+        csrf_token,
+    )
+
 
 @pytest.mark.e2e
 def test_delete_connection(authenticated_page: Page, base_url: str, csrf_token: str) -> None:
     """Delete a connection -> removed from list."""
     page = authenticated_page
 
-    result = api_get(page, "/api/servers")
-    servers = result if isinstance(result, list) else result.get("servers", [])
-
-    if not servers:
-        pytest.skip("No servers available to test delete")
-
-    server_id = servers[0]["id"]
-
-    connections_result = api_get(page, f"/api/servers/{server_id}/connections")
-
-    connections = (
-        connections_result
-        if isinstance(connections_result, list)
-        else connections_result.get("connections", [])
+    # Create a test user and connection to delete
+    add_user_result = api_post(
+        page,
+        "/api/users/add/",
+        {
+            "username": "e2e_delete_conn",
+            "password": "TestPass123!",
+            "role": "user",
+            "enabled": True,
+        },
+        csrf_token,
     )
 
-    if not connections:
-        pytest.skip("No connections available to test delete")
+    if add_user_result["status"] != 200:
+        pytest.skip("Could not create test user for delete connection test")
 
-    conn_id = connections[0]["id"]
+    users_result = api_get(page, "/api/users/")
+    users = users_result if isinstance(users_result, list) else users_result.get("users", [])
+    test_user = None
+    for u in users:
+        if u.get("username") == "e2e_delete_conn":
+            test_user = u
+            break
+
+    if not test_user:
+        pytest.skip("Test user not found for delete connection test")
+
+    user_id = test_user["id"]
+    server_id = _get_server_id(page)
+
+    # Add a connection to delete
+    conn_result = api_post(
+        page,
+        f"/api/users/{user_id}/connections/add/",
+        {"server_id": server_id, "protocol": "awg2", "name": "e2e_delete_conn"},
+        csrf_token,
+    )
+
+    if conn_result["status"] != 200:
+        api_post(page, f"/api/users/{user_id}/delete/", {}, csrf_token)
+        pytest.skip("Could not create connection for delete test")
+
+    # Get the connection ID from user connections
+    user_conns = api_get(page, f"/api/users/{user_id}/connections/")
+    user_connections = (
+        user_conns if isinstance(user_conns, list) else user_conns.get("connections", [])
+    )
+
+    if not user_connections:
+        api_post(page, f"/api/users/{user_id}/delete/", {}, csrf_token)
+        pytest.skip("No connection created for delete test")
+
+    conn_to_delete = user_connections[0]
+    conn_id = conn_to_delete["id"]
+    server_id_conn = conn_to_delete["server_id"]
+
     delete_result = api_post(
         page,
-        f"/api/servers/{server_id}/connections/remove",
+        f"/api/servers/{server_id_conn}/connections/remove/",
         {"connection_id": conn_id},
         csrf_token,
     )
 
-    # Delete should respond
+    # Delete should respond (even if it returns an error from the container)
     assert delete_result["body"] is not None
+
+    # Clean up user
+    api_post(page, f"/api/users/{user_id}/delete/", {}, csrf_token)

--- a/tests/e2e/test_my_connections.py
+++ b/tests/e2e/test_my_connections.py
@@ -12,7 +12,7 @@ def _create_test_user(
     """Helper: create a regular user and return user dict."""
     add_result = api_post(
         page,
-        "/api/users/add",
+        "/api/users/add/",
         {
             "username": username,
             "password": "TestPass123!",
@@ -25,8 +25,9 @@ def _create_test_user(
     if add_result["status"] != 200:
         pytest.skip("Could not create test user")
 
-    users_result = api_get(page, "/api/users")
-    users = users_result if isinstance(users_result, list) else []
+    # Find the newly created user — API returns {"users": [...], "total": N, ...}
+    users_result = api_get(page, "/api/users/")
+    users = users_result if isinstance(users_result, list) else users_result.get("users", [])
 
     for u in users:
         if u.get("username") == username:
@@ -74,7 +75,7 @@ def test_create_connection(
     page = authenticated_page
 
     # Get a server to attach connection to
-    result = api_get(page, "/api/servers")
+    result = api_get(page, "/api/servers/")
     servers = result if isinstance(result, list) else result.get("servers", [])
 
     if not servers:
@@ -88,8 +89,8 @@ def test_create_connection(
 
     conn_result = api_post(
         page,
-        f"/api/users/{user_id}/connections/add",
-        {"server_id": server_id, "protocol": "awg", "name": "e2e_user_conn"},
+        f"/api/users/{user_id}/connections/add/",
+        {"server_id": server_id, "protocol": "awg2", "name": "e2e_user_conn"},
         csrf_token,
     )
 
@@ -99,7 +100,7 @@ def test_create_connection(
         assert conn_result["body"].get("status") == "success" or "id" in conn_result["body"]
 
     # Clean up — delete the test user
-    api_post(page, f"/api/users/{user_id}/delete", {}, csrf_token)
+    api_post(page, f"/api/users/{user_id}/delete/", {}, csrf_token)
 
 
 @pytest.mark.e2e
@@ -115,13 +116,13 @@ def test_view_connection_config(
     user_id = test_user["id"]
 
     # Get servers to find a connection
-    servers_result = api_get(page, "/api/servers")
+    servers_result = api_get(page, "/api/servers/")
     servers = (
         servers_result if isinstance(servers_result, list) else servers_result.get("servers", [])
     )
 
     if not servers:
-        api_post(page, f"/api/users/{user_id}/delete", {}, csrf_token)
+        api_post(page, f"/api/users/{user_id}/delete/", {}, csrf_token)
         pytest.skip("No servers available for config test")
 
     server_id = servers[0]["id"]
@@ -129,20 +130,32 @@ def test_view_connection_config(
     # Add a connection for the test user
     conn_result = api_post(
         page,
-        f"/api/users/{user_id}/connections/add",
-        {"server_id": server_id, "protocol": "awg", "name": "e2e_view_conn"},
+        f"/api/users/{user_id}/connections/add/",
+        {"server_id": server_id, "protocol": "awg2", "name": "e2e_view_conn"},
         csrf_token,
     )
 
     if conn_result["status"] != 200:
-        api_post(page, f"/api/users/{user_id}/delete", {}, csrf_token)
+        api_post(page, f"/api/users/{user_id}/delete/", {}, csrf_token)
         pytest.skip("Could not create connection for config test")
+
+    # Get the user's connections to find the connection ID
+    user_conns = api_get(page, f"/api/users/{user_id}/connections/")
+    connections = user_conns if isinstance(user_conns, list) else user_conns.get("connections", [])
+
+    if not connections:
+        api_post(page, f"/api/users/{user_id}/delete/", {}, csrf_token)
+        pytest.skip("No connections available for config test")
+
+    conn = connections[0]
+    conn_id = conn["id"]
+    server_id_conn = conn["server_id"]
 
     # Fetch the connection config via the server API
     config_result = api_post(
         page,
-        f"/api/servers/{server_id}/connections/config",
-        {"connection_id": conn_result["body"].get("id", "")},
+        f"/api/servers/{server_id_conn}/connections/config/",
+        {"connection_id": conn_id},
         csrf_token,
     )
 
@@ -150,7 +163,7 @@ def test_view_connection_config(
     assert config_result["body"] is not None
 
     # Clean up
-    api_post(page, f"/api/users/{user_id}/delete", {}, csrf_token)
+    api_post(page, f"/api/users/{user_id}/delete/", {}, csrf_token)
 
 
 @pytest.mark.e2e

--- a/tests/e2e/test_share.py
+++ b/tests/e2e/test_share.py
@@ -6,54 +6,56 @@ from playwright.sync_api import Page
 from tests.e2e.conftest import api_get, api_post
 
 
+def _find_or_create_user(page: Page, csrf_token: str, username: str = "e2e_share_user") -> dict:
+    """Find a user by username, or create one if not found."""
+    users_result = api_get(page, "/api/users/")
+    users = users_result if isinstance(users_result, list) else users_result.get("users", [])
+
+    for u in users:
+        if u.get("username") == username:
+            return u
+
+    # Not found — create one
+    add_result = api_post(
+        page,
+        "/api/users/add/",
+        {
+            "username": username,
+            "password": "TestPass123!",
+            "role": "user",
+            "enabled": True,
+        },
+        csrf_token,
+    )
+
+    if add_result["status"] != 200:
+        pytest.skip("Could not create user for share test")
+
+    # Re-fetch to get full user record
+    users_result2 = api_get(page, "/api/users/")
+    users2 = users_result2 if isinstance(users_result2, list) else users_result2.get("users", [])
+
+    for u in users2:
+        if u.get("username") == username:
+            return u
+
+    pytest.skip("Test user not found after creation")
+    return {}  # unreachable
+
+
 @pytest.mark.e2e
 def test_enable_sharing(authenticated_page: Page, base_url: str, csrf_token: str) -> None:
     """Set up share for a user connection -> share link generated."""
     page = authenticated_page
 
-    # Get users (need a user to share)
-    users_result = api_get(page, "/api/users")
-
-    users = users_result if isinstance(users_result, list) else []
-    if not users:
-        # Create a test user
-        add_result = api_post(
-            page,
-            "/api/users/add",
-            {
-                "username": "e2e_share_user",
-                "password": "TestPass123!",
-                "role": "user",
-                "enabled": True,
-            },
-            csrf_token,
-        )
-        if add_result["status"] != 200:
-            pytest.skip("Could not create user for share test")
-
-        users_result2 = api_get(page, "/api/users")
-        users = users_result2 if isinstance(users_result2, list) else []
-
-    # Find our test user or use the first non-admin user
-    target_user = None
-    for u in users:
-        if u.get("username") == "e2e_share_user" or u.get("role") == "user":
-            target_user = u
-            break
-
-    if not target_user and users:
-        target_user = users[0]
-
-    if not target_user:
-        pytest.skip("No user available for share test")
-
+    target_user = _find_or_create_user(page, csrf_token, "e2e_share_user")
     user_id = target_user["id"]
 
     # Enable sharing via the setup endpoint
     share_result = api_post(
         page,
-        f"/api/users/{user_id}/share/setup",
-        {"enabled": True, "password": "TestPass123!"},
+        f"/api/users/{user_id}/share/setup/",
+        {"enabled": True, "password": "sharetest123"},
         csrf_token,
     )
 
@@ -66,7 +68,7 @@ def test_enable_sharing(authenticated_page: Page, base_url: str, csrf_token: str
     # Clean up — disable sharing
     api_post(
         page,
-        f"/api/users/{user_id}/share/setup",
+        f"/api/users/{user_id}/share/setup/",
         {"enabled": False},
         csrf_token,
     )
@@ -77,41 +79,14 @@ def test_access_share_link(authenticated_page: Page, base_url: str, csrf_token: 
     """Navigate to share link -> sees share page."""
     page = authenticated_page
 
-    # Create a test user
-    add_result = api_post(
-        page,
-        "/api/users/add",
-        {
-            "username": "e2e_share_access_user",
-            "password": "TestPass123!",
-            "role": "user",
-            "enabled": True,
-        },
-        csrf_token,
-    )
-
-    if add_result["status"] != 200:
-        pytest.skip("Could not create user for share test")
-
-    users_result = api_get(page, "/api/users")
-    users = users_result if isinstance(users_result, list) else []
-
-    target_user = None
-    for u in users:
-        if u.get("username") == "e2e_share_access_user":
-            target_user = u
-            break
-
-    if not target_user:
-        pytest.skip("Test user not found")
-
+    target_user = _find_or_create_user(page, csrf_token, "e2e_share_access_user")
     user_id = target_user["id"]
 
     # Enable sharing
     share_result = api_post(
         page,
-        f"/api/users/{user_id}/share/setup",
-        {"enabled": True, "password": "TestPass123!"},
+        f"/api/users/{user_id}/share/setup/",
+        {"enabled": True, "password": "sharetest123"},
         csrf_token,
     )
 
@@ -134,11 +109,11 @@ def test_access_share_link(authenticated_page: Page, base_url: str, csrf_token: 
     # Clean up
     api_post(
         page,
-        f"/api/users/{user_id}/share/setup",
+        f"/api/users/{user_id}/share/setup/",
         {"enabled": False},
         csrf_token,
     )
-    api_post(page, f"/api/users/{user_id}/delete", {}, csrf_token)
+    api_post(page, f"/api/users/{user_id}/delete/", {}, csrf_token)
 
 
 @pytest.mark.e2e
@@ -148,54 +123,29 @@ def test_download_config_from_share(
     """Authenticate on share page, download config -> gets config file."""
     page = authenticated_page
 
-    # This test requires a user with share enabled AND a connection.
-    # If no servers/connections exist, skip.
-    servers_result = api_get(page, "/api/servers")
-    servers = servers_result if isinstance(servers_result, list) else []
+    # This test requires a server for connection creation
+    servers_result = api_get(page, "/api/servers/")
+    servers = (
+        servers_result if isinstance(servers_result, list) else servers_result.get("servers", [])
+    )
 
     if not servers:
         pytest.skip("No servers available for share config test")
 
     # Create a test user with share enabled
-    add_result = api_post(
-        page,
-        "/api/users/add",
-        {
-            "username": "e2e_share_dl_user",
-            "password": "TestPass123!",
-            "role": "user",
-            "enabled": True,
-        },
-        csrf_token,
-    )
-
-    if add_result["status"] != 200:
-        pytest.skip("Could not create user for share download test")
-
-    users_result = api_get(page, "/api/users")
-    users = users_result if isinstance(users_result, list) else []
-
-    target_user = None
-    for u in users:
-        if u.get("username") == "e2e_share_dl_user":
-            target_user = u
-            break
-
-    if not target_user:
-        pytest.skip("Test user not found")
-
+    target_user = _find_or_create_user(page, csrf_token, "e2e_share_dl_user")
     user_id = target_user["id"]
 
     # Enable sharing with password
     share_result = api_post(
         page,
-        f"/api/users/{user_id}/share/setup",
-        {"enabled": True, "password": "TestPass123!"},
+        f"/api/users/{user_id}/share/setup/",
+        {"enabled": True, "password": "sharetest123"},
         csrf_token,
     )
 
     if share_result["status"] != 200:
-        api_post(page, f"/api/users/{user_id}/delete", {}, csrf_token)
+        api_post(page, f"/api/users/{user_id}/delete/", {}, csrf_token)
         pytest.skip("Could not enable sharing")
 
     share_token = share_result["body"].get("share_token")
@@ -203,7 +153,7 @@ def test_download_config_from_share(
     # Authenticate on share page via Playwright's request API (bypasses CSP)
     auth_result = page.request.post(
         f"{base_url}/api/share/{share_token}/auth",
-        data={"password": "TestPass123!"},
+        data={"password": "sharetest123"},
         headers={
             "X-CSRF-Token": csrf_token,
             "Content-Type": "application/json",
@@ -217,8 +167,8 @@ def test_download_config_from_share(
     # Clean up
     api_post(
         page,
-        f"/api/users/{user_id}/share/setup",
+        f"/api/users/{user_id}/share/setup/",
         {"enabled": False},
         csrf_token,
     )
-    api_post(page, f"/api/users/{user_id}/delete", {}, csrf_token)
+    api_post(page, f"/api/users/{user_id}/delete/", {}, csrf_token)

--- a/tests/e2e/test_users.py
+++ b/tests/e2e/test_users.py
@@ -6,12 +6,23 @@ from playwright.sync_api import Page
 from tests.e2e.conftest import api_get, api_post
 
 
+def _get_users(page: Page) -> list:
+    """Fetch users from the API and return a list.
+
+    The API returns {"users": [...], "total": N, ...} — extract the users list.
+    """
+    users_result = api_get(page, "/api/users/")
+    if isinstance(users_result, list):
+        return users_result
+    return users_result.get("users", [])
+
+
 @pytest.mark.e2e
 def test_user_list_loads(authenticated_page: Page, base_url: str) -> None:
     """Navigate to /users -> sees user list."""
     page = authenticated_page
 
-    result = api_get(page, "/api/users")
+    result = api_get(page, "/api/users/")
 
     # Should return a list of users (may include admin)
     if isinstance(result, dict) and "error" in result:
@@ -28,7 +39,7 @@ def test_add_user(authenticated_page: Page, base_url: str, csrf_token: str) -> N
 
     add_result = api_post(
         page,
-        "/api/users/add",
+        "/api/users/add/",
         {
             "username": "e2e_test_user",
             "password": "TestPass123!",
@@ -41,12 +52,14 @@ def test_add_user(authenticated_page: Page, base_url: str, csrf_token: str) -> N
     # Should succeed or return validation error
     body = add_result["body"]
     if add_result["status"] == 200:
-        assert body.get("status") == "success" or "id" in body
+        assert body.get("status") == "success" or "user_id" in body
 
     # Clean up — try to delete the test user
-    if add_result["status"] == 200 and "id" in body:
-        user_id = body["id"]
-        api_post(page, f"/api/users/{user_id}/delete", {}, csrf_token)
+    if add_result["status"] == 200:
+        # API returns user_id, not id
+        user_id = body.get("user_id")
+        if user_id:
+            api_post(page, f"/api/users/{user_id}/delete/", {}, csrf_token)
 
 
 @pytest.mark.e2e
@@ -57,7 +70,7 @@ def test_edit_user(authenticated_page: Page, base_url: str, csrf_token: str) -> 
     # Create a test user first
     add_result = api_post(
         page,
-        "/api/users/add",
+        "/api/users/add/",
         {
             "username": "e2e_edit_user",
             "password": "TestPass123!",
@@ -70,10 +83,8 @@ def test_edit_user(authenticated_page: Page, base_url: str, csrf_token: str) -> 
     if add_result["status"] != 200:
         pytest.skip("Could not create test user for edit test")
 
-    users_result = api_get(page, "/api/users")
-    users = users_result if isinstance(users_result, list) else []
-
-    # Find our test user
+    # Find our test user in the users list
+    users = _get_users(page)
     test_user = None
     for u in users:
         if u.get("username") == "e2e_edit_user":
@@ -88,7 +99,7 @@ def test_edit_user(authenticated_page: Page, base_url: str, csrf_token: str) -> 
     # Edit the user
     edit_result = api_post(
         page,
-        f"/api/users/{user_id}/update",
+        f"/api/users/{user_id}/update/",
         {"username": "e2e_edit_user_renamed"},
         csrf_token,
     )
@@ -97,7 +108,7 @@ def test_edit_user(authenticated_page: Page, base_url: str, csrf_token: str) -> 
     assert edit_result["body"] is not None
 
     # Clean up
-    api_post(page, f"/api/users/{user_id}/delete", {}, csrf_token)
+    api_post(page, f"/api/users/{user_id}/delete/", {}, csrf_token)
 
 
 @pytest.mark.e2e
@@ -108,7 +119,7 @@ def test_toggle_user(authenticated_page: Page, base_url: str, csrf_token: str) -
     # Create a test user
     add_result = api_post(
         page,
-        "/api/users/add",
+        "/api/users/add/",
         {
             "username": "e2e_toggle_user",
             "password": "TestPass123!",
@@ -121,9 +132,7 @@ def test_toggle_user(authenticated_page: Page, base_url: str, csrf_token: str) -
     if add_result["status"] != 200:
         pytest.skip("Could not create test user for toggle test")
 
-    users_result = api_get(page, "/api/users")
-    users = users_result if isinstance(users_result, list) else []
-
+    users = _get_users(page)
     test_user = None
     for u in users:
         if u.get("username") == "e2e_toggle_user":
@@ -136,13 +145,12 @@ def test_toggle_user(authenticated_page: Page, base_url: str, csrf_token: str) -
     user_id = test_user["id"]
 
     # Toggle user enabled status
-    toggle_result = api_post(page, f"/api/users/{user_id}/toggle", {}, csrf_token)
-
+    toggle_result = api_post(page, f"/api/users/{user_id}/toggle/", {}, csrf_token)
     # Should respond
     assert toggle_result["body"] is not None
 
     # Clean up
-    api_post(page, f"/api/users/{user_id}/delete", {}, csrf_token)
+    api_post(page, f"/api/users/{user_id}/delete/", {}, csrf_token)
 
 
 @pytest.mark.e2e
@@ -151,8 +159,10 @@ def test_add_user_connection(authenticated_page: Page, base_url: str, csrf_token
     page = authenticated_page
 
     # Get servers first
-    servers_result = api_get(page, "/api/servers")
-    servers = servers_result if isinstance(servers_result, list) else []
+    servers_result = api_get(page, "/api/servers/")
+    servers = (
+        servers_result if isinstance(servers_result, list) else servers_result.get("servers", [])
+    )
 
     if not servers:
         pytest.skip("No servers available for user connection test")
@@ -160,9 +170,9 @@ def test_add_user_connection(authenticated_page: Page, base_url: str, csrf_token
     # Create a test user
     add_result = api_post(
         page,
-        "/api/users/add",
+        "/api/users/add/",
         {
-            "username": "e2e_conn_user",
+            "username": "e2e_user_conn",
             "password": "TestPass123!",
             "role": "user",
             "enabled": True,
@@ -173,12 +183,10 @@ def test_add_user_connection(authenticated_page: Page, base_url: str, csrf_token
     if add_result["status"] != 200:
         pytest.skip("Could not create test user for connection test")
 
-    users_result = api_get(page, "/api/users")
-    users = users_result if isinstance(users_result, list) else []
-
+    users = _get_users(page)
     test_user = None
     for u in users:
-        if u.get("username") == "e2e_conn_user":
+        if u.get("username") == "e2e_user_conn":
             test_user = u
             break
 
@@ -191,10 +199,10 @@ def test_add_user_connection(authenticated_page: Page, base_url: str, csrf_token
     # Add connection for user
     conn_result = api_post(
         page,
-        f"/api/users/{user_id}/connections/add",
+        f"/api/users/{user_id}/connections/add/",
         {
             "server_id": server_id,
-            "protocol": "awg",
+            "protocol": "awg2",
             "name": "e2e_user_conn",
         },
         csrf_token,
@@ -203,7 +211,7 @@ def test_add_user_connection(authenticated_page: Page, base_url: str, csrf_token
     assert conn_result["body"] is not None
 
     # Clean up
-    api_post(page, f"/api/users/{user_id}/delete", {}, csrf_token)
+    api_post(page, f"/api/users/{user_id}/delete/", {}, csrf_token)
 
 
 @pytest.mark.e2e
@@ -214,7 +222,7 @@ def test_delete_user(authenticated_page: Page, base_url: str, csrf_token: str) -
     # Create a test user
     add_result = api_post(
         page,
-        "/api/users/add",
+        "/api/users/add/",
         {
             "username": "e2e_delete_user",
             "password": "TestPass123!",
@@ -227,9 +235,7 @@ def test_delete_user(authenticated_page: Page, base_url: str, csrf_token: str) -
     if add_result["status"] != 200:
         pytest.skip("Could not create test user for delete test")
 
-    users_result = api_get(page, "/api/users")
-    users = users_result if isinstance(users_result, list) else []
-
+    users = _get_users(page)
     test_user = None
     for u in users:
         if u.get("username") == "e2e_delete_user":
@@ -242,16 +248,15 @@ def test_delete_user(authenticated_page: Page, base_url: str, csrf_token: str) -
     user_id = test_user["id"]
 
     # Delete the user
-    delete_result = api_post(page, f"/api/users/{user_id}/delete", {}, csrf_token)
+    delete_result = api_post(page, f"/api/users/{user_id}/delete/", {}, csrf_token)
 
     # Should succeed
     assert delete_result["body"] is not None
 
     # Verify user no longer exists
-    users_after = api_get(page, "/api/users")
-    if isinstance(users_after, list):
-        user_ids = [u["id"] for u in users_after]
-        assert user_id not in user_ids
+    users_after = _get_users(page)
+    user_ids = [u["id"] for u in users_after]
+    assert user_id not in user_ids
 
 
 @pytest.mark.e2e
@@ -263,7 +268,7 @@ def test_xss_prevention(authenticated_page: Page, base_url: str, csrf_token: str
 
     add_result = api_post(
         page,
-        "/api/users/add",
+        "/api/users/add/",
         {
             "username": xss_payload,
             "password": "TestPass123!",
@@ -287,8 +292,7 @@ def test_xss_prevention(authenticated_page: Page, base_url: str, csrf_token: str
         assert "<script>alert(" not in content or "&lt;script&gt;" in content
 
         # Clean up
-        users_result = api_get(page, "/api/users")
-        users = users_result if isinstance(users_result, list) else []
+        users = _get_users(page)
         for u in users:
             if xss_payload in u.get("username", ""):
-                api_post(page, f"/api/users/{u['id']}/delete", {}, csrf_token)
+                api_post(page, f"/api/users/{u['id']}/delete/", {}, csrf_token)


### PR DESCRIPTION
## What

Corrects API response key mismatches and endpoint URLs in the E2E test suite that caused 15 tests to be skipped.

## Why

E2E tests were failing/skipping because:
- `test_connections.py` fetched connections via `/api/servers/{id}/connections` which returns `{"clients": []}`, not `{"connections": [...]}` — wrong endpoint for the data shape needed.
- `test_users.py` and `test_my_connections.py` did not handle the dict response format `{"users": [...], "total": N}` returned by the API.
- Missing trailing slashes caused HTTP 307 redirects (FastAPI `redirect_slashes`).
- Protocol name `awg` did not match the dev server environment (`awg2`).

## Technical approach

- Switched connection lookups to `/api/users/{id}/connections/` endpoint which returns the expected `{"connections": [...]}` format.
- Added response parsing helpers (_get_admin_connections, _get_server_id, _create_test_user, _find_or_create_user, _get_users) that handle both list and dict API response formats.
- Added trailing slashes to all API endpoint URLs consistently.
- Changed protocol references from `awg` to `awg2`.
- Fixed `user_id` vs `id` key name in add-user response.

Files changed:
- `tests/e2e/test_connections.py`
- `tests/e2e/test_my_connections.py`
- `tests/e2e/test_share.py`
- `tests/e2e/test_users.py`
- `WORKLOG.md`

## Testing

QA approved by qa_bot:
- 641/641 unit tests passing
- black/flake8 clean on all 4 modified E2E test files
- All 4 files compile without syntax errors
- No MEDIUM+ security findings
- Test-only changes — zero application code modified

Relates to E2E test stability across the suite.