### PR TITLE
Fix E2E config/toggle tests: self-contained connections + password fix

### DIFF
--- a/tests/e2e/test_connections.py
+++ b/tests/e2e/test_connections.py
@@ -113,14 +113,49 @@ def test_connection_config_and_qr(authenticated_page: Page, base_url: str, csrf_
     """View connection config -> sees config text and QR code."""
     page = authenticated_page
 
-    # Get connections via user endpoint (server endpoint returns {"clients": []})
-    connections = _get_admin_connections(page)
+    server_id = _get_server_id(page)
+
+    # Create a test user and connection
+    add_result = api_post(
+        page,
+        "/api/users/add",
+        {
+            "username": "e2e_config_test",
+            "password": "TestPass123!",
+            "role": "user",
+            "enabled": True,
+        },
+        csrf_token,
+    )
+
+    if add_result["status"] != 200:
+        pytest.skip("Could not create test user for config test")
+
+    users_result = api_get(page, "/api/users/?size=100")
+    users = users_result if isinstance(users_result, list) else users_result.get("users", [])
+    test_user = next((u for u in users if u.get("username") == "e2e_config_test"), None)
+
+    if not test_user:
+        pytest.skip("Test user not found for config test")
+
+    user_id = test_user["id"]
+
+    conn_result = api_post(
+        page,
+        f"/api/users/{user_id}/connections/add",
+        {"server_id": server_id, "protocol": "awg2", "name": "e2e_config_test"},
+        csrf_token,
+    )
+
+    # Get the user's connections
+    user_conns = api_get(page, f"/api/users/{user_id}/connections/")
+    connections = user_conns if isinstance(user_conns, list) else user_conns.get("connections", [])
 
     if not connections:
-        pytest.skip("No connections available to test config view")
+        api_post(page, f"/api/users/{user_id}/delete", {}, csrf_token)
+        pytest.skip("No connection created for config test")
 
     conn = connections[0]
-    server_id = conn["server_id"]
     conn_id = conn["id"]
 
     config_result = api_post(
@@ -133,19 +168,58 @@ def test_connection_config_and_qr(authenticated_page: Page, base_url: str, csrf_
     # Config endpoint should respond
     assert config_result["body"] is not None
 
+    # Clean up
+    api_post(page, f"/api/users/{user_id}/delete", {}, csrf_token)
+
 
 @pytest.mark.e2e
 def test_toggle_connection(authenticated_page: Page, base_url: str, csrf_token: str) -> None:
     """Enable/disable a connection -> status changes."""
     page = authenticated_page
 
-    connections = _get_admin_connections(page)
+    server_id = _get_server_id(page)
+
+    # Create a test user and connection
+    add_result = api_post(
+        page,
+        "/api/users/add",
+        {
+            "username": "e2e_toggle_test",
+            "password": "TestPass123!",
+            "role": "user",
+            "enabled": True,
+        },
+        csrf_token,
+    )
+
+    if add_result["status"] != 200:
+        pytest.skip("Could not create test user for toggle test")
+
+    users_result = api_get(page, "/api/users/?size=100")
+    users = users_result if isinstance(users_result, list) else users_result.get("users", [])
+    test_user = next((u for u in users if u.get("username") == "e2e_toggle_test"), None)
+
+    if not test_user:
+        pytest.skip("Test user not found for toggle test")
+
+    user_id = test_user["id"]
+
+    conn_result = api_post(
+        page,
+        f"/api/users/{user_id}/connections/add",
+        {"server_id": server_id, "protocol": "awg2", "name": "e2e_toggle_test"},
+        csrf_token,
+    )
+
+    # Get the user's connections
+    user_conns = api_get(page, f"/api/users/{user_id}/connections/")
+    connections = user_conns if isinstance(user_conns, list) else user_conns.get("connections", [])
 
     if not connections:
-        pytest.skip("No connections available to test toggle")
+        api_post(page, f"/api/users/{user_id}/delete", {}, csrf_token)
+        pytest.skip("No connection created for toggle test")
 
     conn = connections[0]
-    server_id = conn["server_id"]
     conn_id = conn["id"]
 
     toggle_result = api_post(
@@ -165,6 +239,9 @@ def test_toggle_connection(authenticated_page: Page, base_url: str, csrf_token: 
         {"connection_id": conn_id},
         csrf_token,
     )
+
+    # Clean up
+    api_post(page, f"/api/users/{user_id}/delete", {}, csrf_token)
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
## What
- Make test_connection_config_and_qr and test_toggle_connection self-contained: create their own user+connection instead of relying on pre-existing data
- Fix remaining 'password': '***' → 'TestPass123!' in newly added test code (2 occurrences)

## Why
These tests were skipping because _get_admin_connections() returned empty — no users had connections on a fresh dev server. They now create, test, and clean up their own data.

The *** password was missed in the earlier py_bot fix — new code added by py_bot still used the 3-char password that fails Pydantic's min_length=8.

## Testing
- 641 unit tests pass
- black/flake8 clean
- test_connection_config_and_qr: PASSES (was skipping)
- test_toggle_connection: PASSES (was skipping)
- Live E2E: 31/36 pass, 3 skipped (rate limit + no VPN data), 2 errors (transient BunkerWeb 502)