### PR TITLE
feat: BackgroundTaskSupervisor + strip sensitive fields from API

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 100
 extend-ignore = E203, W503, E501, E722, F841
-exclude = .git,venv,__pycache__,build,dist
+exclude = .git,.venv,venv,__pycache__,build,dist

--- a/app.py
+++ b/app.py
@@ -48,6 +48,7 @@ from app.services.background import (  # noqa: F401 - re-exports for backward co
     sync_users_with_remnawave,
 )
 from app.services.background_orchestrator import BackgroundTaskOrchestrator
+from app.services.background_supervisor import BackgroundTaskSupervisor
 
 # Re-export schemas for backward compatibility (tests import from app)
 from schemas import (  # noqa: F401
@@ -90,9 +91,10 @@ async def lifespan(app: FastAPI):
     else:
         logger.info("Existing users found, skipping default admin creation")
 
-    # Start periodic background tasks via orchestrator
+    # Start periodic background tasks via supervised orchestrator
     orchestrator = BackgroundTaskOrchestrator()
-    await orchestrator.start()
+    supervisor = BackgroundTaskSupervisor(orchestrator)
+    await supervisor.start()
 
     # Start Telegram bot if enabled
     tg_cfg = db.get_setting("telegram", {})
@@ -105,8 +107,8 @@ async def lifespan(app: FastAPI):
     # --- Shutdown ---
     logger.info("Shutting down...")
 
-    # Stop background task orchestrator
-    await orchestrator.stop()
+    # Stop background task supervisor
+    await supervisor.stop()
 
     # Stop Telegram bot
     try:

--- a/app/routers/servers.py
+++ b/app/routers/servers.py
@@ -32,9 +32,13 @@ router = APIRouter(prefix="/api/servers")
 
 @router.get("/")
 async def api_list_servers(request: Request, user: dict = Depends(get_current_user)):
-    """Return all servers as JSON."""
+    """Return all servers as JSON (sensitive fields stripped)."""
     db = get_db()
     servers = db.get_all_servers()
+    # Strip decrypted credentials from API response — they are for SSHManager only
+    for server in servers:
+        server.pop("password", None)
+        server.pop("private_key", None)
     return servers
 
 

--- a/app/services/background_supervisor.py
+++ b/app/services/background_supervisor.py
@@ -1,0 +1,151 @@
+"""BackgroundTaskSupervisor — wraps BackgroundTaskOrchestrator with crash recovery."""
+
+import asyncio
+import logging
+import time
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class BackgroundTaskSupervisor:
+    """Supervises the BackgroundTaskOrchestrator's background task.
+
+    Adds crash recovery, restart limiting, and health visibility.
+    """
+
+    def __init__(
+        self,
+        orchestrator,
+        max_restarts: int = 3,
+        restart_window: float = 300.0,
+    ) -> None:
+        self._orchestrator = orchestrator
+        self._task: Optional[asyncio.Task] = None
+        self._max_restarts = max_restarts
+        self._restart_window = restart_window  # seconds
+        self._restart_timestamps: list[float] = []
+        self._crash_count: int = 0
+        self._last_success: Optional[float] = None
+        self._stopping: bool = False
+        self._restart_task: Optional[asyncio.Task] = None
+
+    async def start(self) -> None:
+        """Start the supervised background task."""
+        self._task = asyncio.create_task(self._supervised_loop())
+        logger.info("Background task supervisor started")
+
+    async def stop(self, timeout: float = 10.0) -> None:
+        """Gracefully stop the supervised task with timeout."""
+        self._stopping = True
+
+        # Cancel any in-flight restart delay
+        if self._restart_task and not self._restart_task.done():
+            self._restart_task.cancel()
+            try:
+                await self._restart_task
+            except asyncio.CancelledError:
+                pass
+        self._restart_task = None
+
+        if self._task and not self._task.done():
+            # Delegate stop to orchestrator with its own timeout
+            try:
+                await asyncio.wait_for(self._orchestrator.stop(), timeout=timeout)
+            except asyncio.TimeoutError:
+                logger.warning("Orchestrator stop timed out after %.1fs, forcing cancel", timeout)
+            except Exception as e:
+                logger.error("Error during orchestrator stop: %s", e)
+
+            try:
+                await asyncio.wait_for(asyncio.shield(self._task), timeout=timeout)
+            except asyncio.TimeoutError:
+                logger.warning("Background task did not stop within %.1fs, cancelling", timeout)
+                self._task.cancel()
+                try:
+                    await self._task
+                except asyncio.CancelledError:
+                    pass
+            except asyncio.CancelledError:
+                pass
+        logger.info("Background task supervisor stopped")
+
+    @property
+    def crash_count(self) -> int:
+        return self._crash_count
+
+    @property
+    def restart_count(self) -> int:
+        return len(self._restart_timestamps)
+
+    @property
+    def last_success_time(self) -> Optional[float]:
+        return self._last_success
+
+    def is_healthy(self) -> bool:
+        """Report health status. Unhealthy if exhausted restarts."""
+        now = time.monotonic()
+        recent = [t for t in self._restart_timestamps if now - t < self._restart_window]
+        return len(recent) < self._max_restarts
+
+    def _should_restart(self) -> bool:
+        """Check if restart is allowed under the fixed-window limit."""
+        now = time.monotonic()
+        # Prune old timestamps
+        self._restart_timestamps = [
+            t for t in self._restart_timestamps if now - t < self._restart_window
+        ]
+        return len(self._restart_timestamps) < self._max_restarts
+
+    async def _supervised_loop(self) -> None:
+        """Wrap the orchestrator's run loop with supervision."""
+        await self._orchestrator.start()
+        # Wait for the orchestrator's task to finish
+        orch_task = self._orchestrator._task
+        if orch_task is None:
+            logger.error("Orchestrator failed to create task")
+            return
+
+        try:
+            await orch_task
+        except asyncio.CancelledError:
+            logger.info("Background task cancelled (normal shutdown)")
+            raise
+        except Exception as e:
+            self._crash_count += 1
+            logger.critical(
+                "Background task crashed unexpectedly: %s (crash #%d)",
+                e,
+                self._crash_count,
+                exc_info=True,
+            )
+            if self._stopping:
+                logger.info("Supervisor is stopping, not restarting after crash")
+                return
+            if self._should_restart():
+                self._restart_timestamps.append(time.monotonic())
+                logger.warning(
+                    "Restarting background task (restart %d/%d in last %ds)",
+                    len(self._restart_timestamps),
+                    self._max_restarts,
+                    self._restart_window,
+                )
+                self._restart_task = asyncio.create_task(self._restart_after_delay())
+            else:
+                logger.critical(
+                    "Background task restart limit exhausted (%d crashes in %ds). "
+                    "Manual intervention required.",
+                    self._max_restarts,
+                    self._restart_window,
+                )
+
+    async def _restart_after_delay(self, delay: float = 5.0) -> None:
+        """Restart the orchestrator after a brief delay."""
+        logger.info("Waiting %.1fs before restarting background task...", delay)
+        await asyncio.sleep(delay)
+        if self._stopping:
+            logger.info("Supervisor is stopping, skipping restart")
+            return
+        # Reset orchestrator internal state
+        self._orchestrator._task = None
+        await self.start()

--- a/tests/test_api_servers_list.py
+++ b/tests/test_api_servers_list.py
@@ -125,3 +125,66 @@ class TestApiListServers:
             assert alpha["protocols"]["awg"]["installed"] is True
         finally:
             app.app.dependency_overrides.clear()
+
+    @patch("app.routers.servers.get_db")
+    def test_api_list_servers_strips_sensitive_fields(self, mock_get_db):
+        """GET /api/servers response has no password or private_key fields."""
+        import app
+
+        srv_db = Database(tempfile.NamedTemporaryFile(suffix=".db", delete=False).name)
+        srv_db.create_user(
+            {
+                "id": "admin-1",
+                "username": "admin",
+                "password_hash": "hashed",
+                "enabled": True,
+                "traffic_limit": 0,
+                "traffic_used": 0,
+                "limits": {},
+            }
+        )
+        # Create servers with real credentials so we can verify they get stripped
+        srv_db.create_server(
+            {
+                "name": "Sensitive Server",
+                "host": "sens.example.com",
+                "username": "root",
+                "password": "supersecret",
+                "private_key": "-----BEGIN RSA PRIVATE KEY-----\n...",
+                "protocols": {},
+            }
+        )
+        srv_db.create_server(
+            {
+                "name": "No Creds Server",
+                "host": "nocreds.example.com",
+                "username": "root",
+                "password": "",
+                "private_key": "",
+                "protocols": {},
+            }
+        )
+        mock_get_db.return_value = srv_db
+        app.app.dependency_overrides[get_current_user] = lambda: srv_db.get_user("admin-1")
+        try:
+            client = create_csrf_client()
+            response = client.get("/api/servers")
+            assert response.status_code == 200
+            data = response.json()
+            assert len(data) == 2
+            for server in data:
+                assert (
+                    "password" not in server
+                ), f"Server '{server.get('name')}' leaked password field"
+                assert (
+                    "private_key" not in server
+                ), f"Server '{server.get('name')}' leaked private_key field"
+            # Verify non-sensitive fields are still present
+            assert data[0]["name"] == "Sensitive Server"
+            assert data[0]["host"] == "sens.example.com"
+            assert data[0]["username"] == "root"
+        finally:
+            app.app.dependency_overrides.clear()
+            conn = srv_db._get_conn()
+            conn.close()
+            os.unlink(srv_db.db_path)

--- a/tests/test_background_supervisor.py
+++ b/tests/test_background_supervisor.py
@@ -1,0 +1,440 @@
+"""Unit tests for BackgroundTaskSupervisor (TASK: background-task-no-supervision).
+
+Tests cover:
+- Normal start/stop cycle
+- Crash recovery and automatic restart
+- Restart limit enforcement
+- Health check (is_healthy)
+- Graceful shutdown with timeout
+- CancelledError not treated as crash
+"""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Mock Orchestrators
+# ---------------------------------------------------------------------------
+
+
+class MockOrchestrator:
+    """Simple mock orchestrator with configurable crash/hang behavior.
+
+    To simulate a crash: set _crash_trigger, then wait for the task to die.
+    """
+
+    def __init__(self, hang_on_stop: bool = False) -> None:
+        self._task = None
+        self.hang_on_stop = hang_on_stop
+        self.start_calls = 0
+        self.stop_calls = 0
+        self._crash_trigger: asyncio.Event = asyncio.Event()
+
+    async def start(self) -> None:
+        self.start_calls += 1
+        self._crash_trigger.clear()
+
+        async def _run() -> None:
+            # Wait for either cancel signal or crash trigger
+            cancel_evt = asyncio.Event()
+
+            async def _watch_crash() -> None:
+                await self._crash_trigger.wait()
+                cancel_evt.set()
+
+            asyncio.ensure_future(_watch_crash())
+
+            await cancel_evt.wait()
+            if self._crash_trigger.is_set():
+                raise RuntimeError("Simulated crash")
+
+        self._task = asyncio.create_task(_run())
+
+    async def stop(self) -> None:
+        self.stop_calls += 1
+        if self.hang_on_stop:
+            await asyncio.Event().wait()  # hang forever
+        if self._task and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+
+    async def trigger_crash(self) -> None:
+        """Signal the running task to crash."""
+        self._crash_trigger.set()
+        # Give the task a chance to process
+        await asyncio.sleep(0.05)
+
+
+class CountingCrashOrchestrator:
+    """Orchestrator that crashes a fixed number of times, then runs normally."""
+
+    def __init__(self, num_crashes: int = 1) -> None:
+        self._task = None
+        self._calls = 0
+        self._num_crashes = num_crashes
+        self.start_calls = 0
+        self.stop_calls = 0
+
+    async def start(self) -> None:
+        self._calls += 1
+        self.start_calls += 1
+        should_crash = self._calls <= self._num_crashes
+
+        async def _run() -> None:
+            if should_crash:
+                raise RuntimeError(f"Mock crash #{self._calls}")
+            await asyncio.Event().wait()
+
+        self._task = asyncio.create_task(_run())
+
+    async def stop(self) -> None:
+        self.stop_calls += 1
+        if self._task and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _patch_restart_immediate(supervisor) -> None:
+    """Replace _restart_after_delay with an immediate restart (no sleep)."""
+
+    async def immediate_restart(delay: float = 0) -> None:
+        supervisor._orchestrator._task = None
+        await supervisor.start()
+
+    supervisor._restart_after_delay = immediate_restart
+
+
+@pytest.fixture
+def mock_orch():
+    """Return a fresh MockOrchestrator for each test."""
+    return MockOrchestrator()
+
+
+# ---------------------------------------------------------------------------
+# 1. Normal Start/Stop
+# ---------------------------------------------------------------------------
+
+
+class TestStartStop:
+    @pytest.mark.asyncio
+    async def test_start_creates_supervised_task(self, mock_orch):
+        from app.services.background_supervisor import BackgroundTaskSupervisor
+
+        supervisor = BackgroundTaskSupervisor(mock_orch)
+        assert supervisor._task is None
+
+        await supervisor.start()
+        assert supervisor._task is not None
+        assert not supervisor._task.done()
+
+        await supervisor.stop()
+
+    @pytest.mark.asyncio
+    async def test_stop_cleans_up_without_crash_increment(self, mock_orch):
+        from app.services.background_supervisor import BackgroundTaskSupervisor
+
+        supervisor = BackgroundTaskSupervisor(mock_orch)
+        await supervisor.start()
+        await asyncio.sleep(0.02)
+
+        await supervisor.stop()
+
+        assert supervisor.crash_count == 0
+        assert supervisor.restart_count == 0
+
+    @pytest.mark.asyncio
+    async def test_stop_calls_orchestrator_stop(self, mock_orch):
+        from app.services.background_supervisor import BackgroundTaskSupervisor
+
+        supervisor = BackgroundTaskSupervisor(mock_orch)
+        await supervisor.start()
+        await asyncio.sleep(0.02)
+
+        assert mock_orch.start_calls == 1
+        await supervisor.stop()
+        assert mock_orch.stop_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_initial_properties(self, mock_orch):
+        from app.services.background_supervisor import BackgroundTaskSupervisor
+
+        supervisor = BackgroundTaskSupervisor(mock_orch)
+        assert supervisor.crash_count == 0
+        assert supervisor.restart_count == 0
+        assert supervisor.last_success_time is None
+        assert supervisor.is_healthy()
+
+
+# ---------------------------------------------------------------------------
+# 2. Crash Recovery
+# ---------------------------------------------------------------------------
+
+
+class TestCrashRecovery:
+    @pytest.mark.asyncio
+    async def test_single_crash_triggers_restart(self, mock_orch):
+        from app.services.background_supervisor import BackgroundTaskSupervisor
+
+        supervisor = BackgroundTaskSupervisor(mock_orch)
+        _patch_restart_immediate(supervisor)
+
+        await supervisor.start()
+        await asyncio.sleep(0.02)
+
+        # Trigger crash from inside the mock task
+        await mock_orch.trigger_crash()
+        await asyncio.sleep(0.15)
+
+        assert supervisor.crash_count == 1
+        assert supervisor.restart_count == 1
+        assert supervisor.is_healthy()
+        assert mock_orch.start_calls >= 2  # original + restart
+
+        await supervisor.stop()
+
+    @pytest.mark.asyncio
+    async def test_restart_creates_new_orchestrator_task(self, mock_orch):
+        from app.services.background_supervisor import BackgroundTaskSupervisor
+
+        supervisor = BackgroundTaskSupervisor(mock_orch)
+        _patch_restart_immediate(supervisor)
+
+        await supervisor.start()
+        await asyncio.sleep(0.02)
+
+        old_task = mock_orch._task
+        await mock_orch.trigger_crash()
+        await asyncio.sleep(0.15)
+
+        # After restart, a new orchestrator task should exist
+        assert mock_orch._task is not None
+        assert mock_orch._task is not old_task
+
+        await supervisor.stop()
+
+    @pytest.mark.asyncio
+    async def test_multiple_crashes_increment_count(self, mock_orch):
+        from app.services.background_supervisor import BackgroundTaskSupervisor
+
+        supervisor = BackgroundTaskSupervisor(mock_orch, max_restarts=5)
+        _patch_restart_immediate(supervisor)
+
+        await supervisor.start()
+        await asyncio.sleep(0.02)
+
+        # Crash twice
+        await mock_orch.trigger_crash()
+        await asyncio.sleep(0.15)
+        assert supervisor.crash_count == 1
+
+        await mock_orch.trigger_crash()
+        await asyncio.sleep(0.15)
+
+        assert supervisor.crash_count == 2
+        assert supervisor.restart_count == 2
+        assert supervisor.is_healthy()
+
+        await supervisor.stop()
+
+
+# ---------------------------------------------------------------------------
+# 3. Restart Limit
+# ---------------------------------------------------------------------------
+
+
+class TestRestartLimit:
+    @pytest.mark.asyncio
+    async def test_max_restarts_enforced(self):
+        """After max_restarts crashes, supervisor stops restarting."""
+        from app.services.background_supervisor import BackgroundTaskSupervisor
+
+        orch = CountingCrashOrchestrator(num_crashes=10)
+        supervisor = BackgroundTaskSupervisor(orch, max_restarts=2)
+        _patch_restart_immediate(supervisor)
+
+        await supervisor.start()
+        await asyncio.sleep(0.3)
+
+        # max_restarts=2: 1 initial crash + 2 restarts = 3 total crashes
+        assert supervisor.crash_count == 3
+        assert supervisor.restart_count == 2
+        assert not supervisor.is_healthy()
+
+        await supervisor.stop()
+
+    @pytest.mark.asyncio
+    async def test_restart_count_cannot_exceed_max(self):
+        from app.services.background_supervisor import BackgroundTaskSupervisor
+
+        orch = CountingCrashOrchestrator(num_crashes=10)
+        supervisor = BackgroundTaskSupervisor(orch, max_restarts=1)
+        _patch_restart_immediate(supervisor)
+
+        await supervisor.start()
+        await asyncio.sleep(0.2)
+
+        # Only 1 restart allowed, so restart_count max is 1
+        assert supervisor.restart_count <= 1
+        assert not supervisor.is_healthy()
+
+        await supervisor.stop()
+
+
+# ---------------------------------------------------------------------------
+# 4. Health Check
+# ---------------------------------------------------------------------------
+
+
+class TestHealthCheck:
+    @pytest.mark.asyncio
+    async def test_is_healthy_when_no_crashes(self, mock_orch):
+        from app.services.background_supervisor import BackgroundTaskSupervisor
+
+        supervisor = BackgroundTaskSupervisor(mock_orch)
+        assert supervisor.is_healthy()
+
+        await supervisor.start()
+        assert supervisor.is_healthy()
+
+        await supervisor.stop()
+        assert supervisor.is_healthy()
+
+    @pytest.mark.asyncio
+    async def test_is_healthy_after_single_crash(self, mock_orch):
+        from app.services.background_supervisor import BackgroundTaskSupervisor
+
+        supervisor = BackgroundTaskSupervisor(mock_orch, max_restarts=5)
+        _patch_restart_immediate(supervisor)
+
+        await supervisor.start()
+        await asyncio.sleep(0.02)
+        await mock_orch.trigger_crash()
+        await asyncio.sleep(0.15)
+
+        # Single crash within limit = still healthy
+        assert supervisor.is_healthy()
+        await supervisor.stop()
+
+    @pytest.mark.asyncio
+    async def test_is_unhealthy_when_restart_limit_reached(self):
+        from app.services.background_supervisor import BackgroundTaskSupervisor
+
+        orch = CountingCrashOrchestrator(num_crashes=10)
+        supervisor = BackgroundTaskSupervisor(orch, max_restarts=2)
+        _patch_restart_immediate(supervisor)
+
+        await supervisor.start()
+        await asyncio.sleep(0.3)
+
+        assert not supervisor.is_healthy()
+        await supervisor.stop()
+
+    def test_is_healthy_ignores_stale_timestamps(self):
+        """Restart timestamps outside the window should not affect health."""
+        import time
+
+        from app.services.background_supervisor import BackgroundTaskSupervisor
+
+        orch = MagicMock()
+        supervisor = BackgroundTaskSupervisor(orch, max_restarts=2, restart_window=10)
+
+        now = time.monotonic()
+        # All timestamps are > 10s old, so they should be ignored
+        supervisor._restart_timestamps = [now - 20.0, now - 15.0, now - 12.0]
+
+        assert supervisor.is_healthy()
+
+    def test_is_healthy_respects_recent_timestamps(self):
+        """Recent restart timestamps within the window should affect health."""
+        import time
+
+        from app.services.background_supervisor import BackgroundTaskSupervisor
+
+        orch = MagicMock()
+        supervisor = BackgroundTaskSupervisor(orch, max_restarts=2, restart_window=60)
+
+        now = time.monotonic()
+        # 3 recent restarts exceed max_restarts=2
+        supervisor._restart_timestamps = [now - 5.0, now - 10.0, now - 15.0]
+
+        assert not supervisor.is_healthy()
+
+
+# ---------------------------------------------------------------------------
+# 5. Graceful Shutdown with Timeout
+# ---------------------------------------------------------------------------
+
+
+class TestStopTimeout:
+    @pytest.mark.asyncio
+    async def test_stop_timeout_when_orchestrator_hangs(self):
+        """Stop should not hang forever when orchestrator.stop() blocks."""
+        from app.services.background_supervisor import BackgroundTaskSupervisor
+
+        orch = MockOrchestrator(hang_on_stop=True)
+        supervisor = BackgroundTaskSupervisor(orch)
+
+        await supervisor.start()
+        await asyncio.sleep(0.02)
+
+        # This should not hang — timeout kicks in and cancels
+        await supervisor.stop(timeout=0.1)
+
+        # Supervisor should have stopped
+        assert supervisor._task is None or supervisor._task.done()
+
+
+# ---------------------------------------------------------------------------
+# 6. CancelledError Propagation
+# ---------------------------------------------------------------------------
+
+
+class TestCancelledError:
+    @pytest.mark.asyncio
+    async def test_cancelled_error_not_treated_as_crash(self, mock_orch):
+        from app.services.background_supervisor import BackgroundTaskSupervisor
+
+        supervisor = BackgroundTaskSupervisor(mock_orch)
+        await supervisor.start()
+        await asyncio.sleep(0.02)
+
+        # Normal stop: orchestrator task gets cancelled
+        await supervisor.stop()
+
+        # CancelledError is NOT a crash — counters stay at 0
+        assert supervisor.crash_count == 0
+        assert supervisor.restart_count == 0
+
+    @pytest.mark.asyncio
+    async def test_cancelled_error_during_crash_recovery_respected(self, mock_orch):
+        """If stop() is called mid-restart-delay, the restart should be cancelled."""
+        from app.services.background_supervisor import BackgroundTaskSupervisor
+
+        supervisor = BackgroundTaskSupervisor(mock_orch)
+        _patch_restart_immediate(supervisor)
+
+        await supervisor.start()
+        await asyncio.sleep(0.02)
+
+        # Cause a crash, which triggers _restart_after_delay
+        await mock_orch.trigger_crash()
+        await asyncio.sleep(0.05)
+
+        # While restart delay is running, call stop
+        await supervisor.stop()
+
+        # The stop should cancel the restart task
+        assert supervisor._restart_task is None


### PR DESCRIPTION
#39: Add BackgroundTaskSupervisor with crash recovery, restart limiting, health visibility

- New file: app/services/background_supervisor.py
- BackgroundTaskSupervisor wraps BackgroundTaskOrchestrator
- Auto-restart on crash (3 restarts per 300s window)
- CRITICAL log on exhaustion
- is_healthy() for future health endpoint
- Graceful shutdown with timeout
- app.py lifespan uses supervisor

#114: Strip password/private_key from GET /api/servers/

- Only api_list_servers() strips fields at the API boundary
- Internal code paths (SSHManager, db.get_server_by_id) unchanged
- New test: test_api_list_servers_strips_sensitive_fields

Tests: 682 passed (17 new supervisor + 1 new API test)
black + flake8 clean
Deployed and verified on dev server