### PR TITLE
feat: add forced password change UI for fresh local startup (#161)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,11 +122,22 @@ The panel will be available at `http://localhost:5000`.
 
 ### First Login
 
+On first startup with an empty database, the panel creates an admin account with a **randomly generated password** and prints it to the console:
+
+```
+============================================================
+  INITIAL ADMIN CREDENTIALS — SAVE THIS NOW
+  Username: admin
+  Password: <random-password>
+  You must change this password on first login.
+============================================================
+```
+
 - **Username**: `admin`
-- **Password**: `admin`
+- **Password**: printed to console on first startup (check Docker logs if running in a container)
 
 > [!IMPORTANT]
-> Change the default `admin` password immediately after first login.
+> You must change this password on first login. The initial password is temporary and should not be reused.
 
 ---
 

--- a/app/routers/pages.py
+++ b/app/routers/pages.py
@@ -9,7 +9,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from app.utils.helpers import get_leaderboard_entries
 from app.utils.templates import tpl
 from config import get_db
-from dependencies import get_current_user
+from dependencies import get_current_user, get_current_user_optional
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +23,16 @@ async def index(request: Request, user: dict = Depends(get_current_user)):
     db = get_db()
     servers = db.get_all_servers()
     return tpl(request, "index.html", servers=servers)
+
+
+@router.get("/change-password", response_class=HTMLResponse)
+async def change_password_page(request: Request):
+    """Render the password change page. Supports ?forced=1 for mandatory changes."""
+    user = get_current_user_optional(request)
+    if not user:
+        return RedirectResponse(url="/login", status_code=302)
+    forced = request.query_params.get("forced", "0") == "1"
+    return tpl(request, "change_password.html", forced=forced)
 
 
 @router.get("/server/{server_id}", response_class=HTMLResponse)

--- a/templates/base.html
+++ b/templates/base.html
@@ -285,6 +285,17 @@
             const res = await fetch(url, opts);
 
             if (res.status === 401 || res.status === 403) {
+                // Check if this is a password_change_required response before redirecting to login
+                try {
+                    const clone = res.clone();
+                    const body = await clone.json();
+                    if (body.password_change_required) {
+                        window.location.href = '/change-password?forced=1';
+                        throw new Error('Password change required');
+                    }
+                } catch (parseErr) {
+                    // Response body wasn't JSON or wasn't password_change_required — proceed to redirect
+                }
                 window.location.href = '/login';
                 throw new Error('Session expired');
             }

--- a/templates/change_password.html
+++ b/templates/change_password.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ site_settings.title or 'Amnezia Panel' }} — {{ _('login') }}</title>
+    <title>{{ site_settings.title or 'Amnezia Panel' }} — {{ _('change_password_title') }}</title>
     <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
     <link rel="stylesheet" href="/static/css/style.css">
     <meta name="csrf-token" content="{{ csrf_token }}">
@@ -61,6 +61,21 @@
             display: block;
         }
 
+        .login-success {
+            background: rgba(34, 197, 94, 0.1);
+            border: 1px solid rgba(34, 197, 94, 0.3);
+            color: #22c55e;
+            padding: var(--space-sm) var(--space-md);
+            border-radius: var(--radius-md);
+            font-size: 0.85rem;
+            margin-bottom: var(--space-md);
+            display: none;
+        }
+
+        .login-success.visible {
+            display: block;
+        }
+
         .lang-check {
             color: var(--success);
             font-weight: 700;
@@ -72,6 +87,32 @@
 
         [dir="ltr"] .lang-check {
             margin-left: auto;
+        }
+
+        .forced-message {
+            text-align: center;
+            color: #f59e0b;
+            font-size: 0.9rem;
+            margin-bottom: var(--space-md);
+            padding: var(--space-sm) var(--space-md);
+            background: rgba(245, 158, 11, 0.1);
+            border: 1px solid rgba(245, 158, 11, 0.3);
+            border-radius: var(--radius-md);
+        }
+
+        .skip-link {
+            text-align: center;
+            margin-top: var(--space-md);
+        }
+
+        .skip-link a {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            text-decoration: none;
+        }
+
+        .skip-link a:hover {
+            color: var(--text);
         }
     </style>
 </head>
@@ -96,42 +137,44 @@
             </div>
 
             <div class="card">
-                <h2 style="font-size:1.2rem; font-weight:600; margin-bottom:var(--space-lg); text-align:center;">{{
-                    _('login_title') }}</h2>
+                <h2 style="font-size:1.2rem; font-weight:600; margin-bottom:var(--space-sm); text-align:center;">{{
+                    _('change_password_title') }}</h2>
 
-                <div class="login-error" id="loginError"></div>
+                {% if forced %}
+                <div class="forced-message">{{ _('password_change_required_msg') }}</div>
+                {% endif %}
 
-                <form id="loginForm" onsubmit="return doLogin(event)">
+                <div class="login-error" id="changePasswordError"></div>
+                <div class="login-success" id="changePasswordSuccess"></div>
+
+                <form id="changePasswordForm" onsubmit="return doChangePassword(event)">
                     <div class="form-group">
-                        <label class="form-label">{{ _('username') }}</label>
-                        <input class="form-input" type="text" id="username" placeholder="admin" required autofocus>
+                        <label class="form-label">{{ _('current_password') }}</label>
+                        <input class="form-input" type="password" id="currentPassword" placeholder="••••••••" required autofocus>
                     </div>
 
                     <div class="form-group">
-                        <label class="form-label">{{ _('password') }}</label>
-                        <input class="form-input" type="password" id="password" placeholder="••••••••" required>
+                        <label class="form-label">{{ _('new_password') }}</label>
+                        <input class="form-input" type="password" id="newPassword" placeholder="••••••••" required>
                     </div>
 
-                    {% if captcha_settings.enabled %}
                     <div class="form-group">
-                        <label class="form-label">{{ _('captcha') }}</label>
-                        <div
-                            style="display: flex; margin-bottom: var(--space-xs); border-radius: var(--radius-md); overflow: hidden; border: 1px solid var(--border-color);">
-                            <img id="captchaImage" src="/api/auth/captcha" alt="Captcha"
-                                style="width: 100%; height: 65px; object-fit: cover; object-position: center; cursor: pointer; background: #fff;"
-                                onclick="refreshCaptcha()" title="{{ _('captcha_hint') }}">
-                        </div>
-                        <input class="form-input" type="text" id="captcha" placeholder="{{ _('captcha_placeholder') }}"
-                            required>
+                        <label class="form-label">{{ _('confirm_new_password') }}</label>
+                        <input class="form-input" type="password" id="confirmPassword" placeholder="••••••••" required>
                     </div>
-                    {% endif %}
 
-                    <button type="submit" class="btn btn-primary" id="loginBtn"
+                    <button type="submit" class="btn btn-primary" id="changePasswordBtn"
                         style="width:100%; margin-top:var(--space-md);">
-                        <span id="loginBtnText">{{ _('login') }}</span>
-                        <div class="spinner hidden" id="loginSpinner"></div>
+                        <span id="changePasswordBtnText">{{ _('change_password_btn') }}</span>
+                        <div class="spinner hidden" id="changePasswordSpinner"></div>
                     </button>
                 </form>
+
+                {% if not forced %}
+                <div class="skip-link">
+                    <a href="/">{{ _('skip_change_password') }}</a>
+                </div>
+                {% endif %}
             </div>
         </div>
     </div>
@@ -233,61 +276,51 @@
             }
         });
 
-        function refreshCaptcha() {
-            const img = document.getElementById('captchaImage');
-            if (img) {
-                img.src = '/api/auth/captcha?' + new Date().getTime();
-            }
-        }
-
-        async function doLogin(e) {
+        async function doChangePassword(e) {
             e.preventDefault();
-            const btn = document.getElementById('loginBtn');
-            const text = document.getElementById('loginBtnText');
-            const spinner = document.getElementById('loginSpinner');
-            const errEl = document.getElementById('loginError');
+            const btn = document.getElementById('changePasswordBtn');
+            const text = document.getElementById('changePasswordBtnText');
+            const spinner = document.getElementById('changePasswordSpinner');
+            const errEl = document.getElementById('changePasswordError');
+            const successEl = document.getElementById('changePasswordSuccess');
 
             btn.disabled = true;
-            text.textContent = _('logging_in');
+            text.textContent = _('changing_password');
             spinner.classList.remove('hidden');
             errEl.classList.remove('visible');
+            successEl.classList.remove('visible');
 
             try {
-                // Get CSRF token from meta tag (works with HttpOnly cookies)
                 const meta = document.querySelector('meta[name="csrf-token"]');
                 const csrfToken = meta ? meta.getAttribute('content') : (document.cookie.match(/csrftoken=([^;]+)/)?.[1] || '');
 
-                const res = await fetch('/api/auth/login', {
+                const res = await fetch('/api/auth/change-password', {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',
                         'X-CSRF-Token': csrfToken,
                     },
                     body: JSON.stringify({
-                        username: document.getElementById('username').value,
-                        password: document.getElementById('password').value,
-                        captcha: document.getElementById('captcha') ? document.getElementById('captcha').value : null,
+                        current_password: document.getElementById('currentPassword').value,
+                        new_password: document.getElementById('newPassword').value,
+                        confirm_password: document.getElementById('confirmPassword').value,
                     }),
                 });
                 const data = await res.json();
                 if (!res.ok) {
-                    throw new Error(data.error || _('login_error'));
+                    throw new Error(data.error || _('change_password_error'));
                 }
-                if (data.password_change_required) {
-                    window.location.href = '/change-password?forced=1';
-                } else {
+                successEl.textContent = _('password_changed_success');
+                successEl.classList.add('visible');
+                setTimeout(() => {
                     window.location.href = '/';
-                }
+                }, 1500);
             } catch (err) {
                 errEl.textContent = err.message;
                 errEl.classList.add('visible');
-                refreshCaptcha();
-                if (document.getElementById('captcha')) {
-                    document.getElementById('captcha').value = '';
-                }
             } finally {
                 btn.disabled = false;
-                text.textContent = _('login');
+                text.textContent = _('change_password_btn');
                 spinner.classList.add('hidden');
             }
         }

--- a/translations/en.json
+++ b/translations/en.json
@@ -306,5 +306,15 @@
     "telemt_config_dir": "Telemt Config Directory",
     "rate_limit_exceeded": "Too many requests. Please try again later.",
     "telemt_config_dir_hint": "Directory on the remote server where Telemt stores its configuration files.",
-    "language_label": "Default Language"
+    "language_label": "Default Language",
+    "change_password_title": "Change Password",
+    "current_password": "Current Password",
+    "new_password": "New Password",
+    "confirm_new_password": "Confirm New Password",
+    "change_password_btn": "Change Password",
+    "changing_password": "Changing...",
+    "change_password_error": "Password change failed",
+    "password_changed_success": "Password changed successfully! Redirecting...",
+    "password_change_required_msg": "You must change your password before continuing.",
+    "skip_change_password": "Skip for now"
 }

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -306,5 +306,15 @@
     "telemt_config_dir": "Директория конфигурации Telemt",
     "rate_limit_exceeded": "Слишком много запросов. Попробуйте позже.",
     "telemt_config_dir_hint": "Директория на удалённом сервере, где Telemt хранит файлы конфигурации.",
-    "language_label": "Язык по умолчанию"
+    "language_label": "Язык по умолчанию",
+    "change_password_title": "Смена пароля",
+    "current_password": "Текущий пароль",
+    "new_password": "Новый пароль",
+    "confirm_new_password": "Подтверждение пароля",
+    "change_password_btn": "Сменить пароль",
+    "changing_password": "Смена...",
+    "change_password_error": "Ошибка смены пароля",
+    "password_changed_success": "Пароль успешно изменён! Перенаправление...",
+    "password_change_required_msg": "Вы должны сменить пароль перед продолжением работы.",
+    "skip_change_password": "Пропустить"
 }


### PR DESCRIPTION
## Problem
When running the application locally with a fresh database (`python3 app.py` + no `panel.db`), ALL `/api/` endpoints return 403 Forbidden after login. The admin user is created with `password_change_required=True`, and the `PasswordChangeRequiredMiddleware` blocks every `/api/` path except login/change-password/captcha. There was no UI to change the password, so users were stuck.

Not reproducible on Docker/production (existing DB has admin with flag already cleared).

## Root Cause
Three-part failure:
1. Lifespan creates admin with `password_change_required: True` (correct security practice)
2. Middleware blocks ALL /api/ paths with 403 (by design)
3. Frontend had zero handling — JS ignored the flag in login response, no change-password UI existed

## Fix
- Login handler detects `password_change_required` and redirects to `/change-password?forced=1`
- New `/change-password` page with forced password change form (i18n: en + ru)
- Global 403 interceptor in `base.html` catches `password_change_required` responses
- When forced, shows mandatory message and hides skip link
- README updated to remove outdated `admin/admin` credentials

## Testing
- 752 tests pass
- black/flake8 clean
- QA APPROVED

## Related
- #162 — Follow-up: first-run setup wizard to replace the random password pattern entirely

Closes #161