### PR TITLE
fix: add password validation hint and i18n error messages in change-password (#164)

### DIFF
--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -119,14 +119,16 @@ async def api_change_password(
     Clears password_change_required flag on success.
     """
 
+    lang = _get_lang(request)
+
     if not verify_password(req.current_password, user["password_hash"]):
-        return JSONResponse({"error": "Current password is incorrect"}, status_code=400)
+        return JSONResponse({"error": _t("current_password_incorrect", lang)}, status_code=400)
 
     if req.new_password != req.confirm_password:
-        return JSONResponse({"error": "New passwords do not match"}, status_code=400)
+        return JSONResponse({"error": _t("passwords_dont_match", lang)}, status_code=400)
 
     if len(req.new_password) < 8:
-        return JSONResponse({"error": "Password must be at least 8 characters"}, status_code=400)
+        return JSONResponse({"error": _t("password_too_short", lang)}, status_code=400)
 
     db = get_db()
     db.update_user(

--- a/templates/change_password.html
+++ b/templates/change_password.html
@@ -156,6 +156,9 @@
                     <div class="form-group">
                         <label class="form-label">{{ _('new_password') }}</label>
                         <input class="form-input" type="password" id="newPassword" placeholder="••••••••" required>
+                        <div class="form-hint" style="font-size: 0.8rem; color: var(--text-muted); margin-top: 4px;">
+                            {{ _('password_min_length_hint') }}
+                        </div>
                     </div>
 
                     <div class="form-group">
@@ -291,6 +294,16 @@
             successEl.classList.remove('visible');
 
             try {
+                const newPassword = document.getElementById('newPassword').value;
+                const confirmPassword = document.getElementById('confirmPassword').value;
+
+                if (newPassword.length < 8) {
+                    throw new Error(_('password_too_short'));
+                }
+                if (newPassword !== confirmPassword) {
+                    throw new Error(_('passwords_dont_match'));
+                }
+
                 const meta = document.querySelector('meta[name="csrf-token"]');
                 const csrfToken = meta ? meta.getAttribute('content') : (document.cookie.match(/csrftoken=([^;]+)/)?.[1] || '');
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -316,5 +316,9 @@
     "change_password_error": "Password change failed",
     "password_changed_success": "Password changed successfully! Redirecting...",
     "password_change_required_msg": "You must change your password before continuing.",
-    "skip_change_password": "Skip for now"
+    "skip_change_password": "Skip for now",
+    "password_min_length_hint": "Minimum 8 characters",
+    "password_too_short": "Password must be at least 8 characters",
+    "passwords_dont_match": "New passwords do not match",
+    "current_password_incorrect": "Current password is incorrect"
 }

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -316,5 +316,9 @@
     "change_password_error": "Ошибка смены пароля",
     "password_changed_success": "Пароль успешно изменён! Перенаправление...",
     "password_change_required_msg": "Вы должны сменить пароль перед продолжением работы.",
-    "skip_change_password": "Пропустить"
+    "skip_change_password": "Пропустить",
+    "password_min_length_hint": "Минимум 8 символов",
+    "password_too_short": "Пароль должен содержать не менее 8 символов",
+    "passwords_dont_match": "Новые пароли не совпадают",
+    "current_password_incorrect": "Текущий пароль неверен"
 }


### PR DESCRIPTION
## Problem

When users try a short password like "1234" in the change-password form, the failure is confusing — no upfront hint about minimum length, and error messages are hardcoded English (not translated).

## Fix

- Added "Minimum 8 characters" hint below the new password field
- Added client-side validation: blocks submit for passwords < 8 chars and mismatched confirmations (before API call)
- Translated all 3 hardcoded English error strings in `api_change_password` using `_t()` i18n
- Added 4 new i18n keys in `en.json` and `ru.json`

## Testing
- 752 tests pass
- black/flake8 clean
- QA APPROVED

Closes #164
