### PR TITLE
fix: correct rate limiting description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,9 +168,8 @@ Note: API authentication is session-based (cookie). A dedicated public REST API 
 
 ### Rate Limiting
 
-Connection rate limits are configurable per-user and globally via **Settings → Connection Limits**:
-- Maximum connections per user
-- Connection rate limit (connections per time window)
+Connection rate limits are configurable globally via **Settings → Connection Limits**:
+- Connection rate limit (requests per time window)
 
 ### Traffic Limits
 


### PR DESCRIPTION
Removes the incorrect claim that per-user rate limiting is available. Rate limits are global only via Settings → Connection Limits.

Also fixes the description from 'connections per time window' to 'requests per time window'.