### PR TITLE
fix: replace 13 hardcoded Russian strings with i18n calls in server.html

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,7 +13,7 @@ from slowapi.errors import RateLimitExceeded
 
 from starlette_csrf import CSRFMiddleware
 
-from app.utils.helpers import _get_client_ip, _t
+from app.utils.helpers import _get_client_ip, _t, _get_default_lang
 from config import _get_secret_key, load_translations, get_db, init_db
 
 from app.routers.auth import router as auth_router
@@ -69,7 +69,7 @@ app.state.limiter = limiter
 
 async def _rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) -> JSONResponse:
     """Custom rate limit exceeded handler with i18n and logging."""
-    lang = request.cookies.get("lang", "ru")
+    lang = request.cookies.get("lang", _get_default_lang())
     logger.warning(
         "Rate limit exceeded: %s %s from %s",
         request.method,

--- a/templates/server.html
+++ b/templates/server.html
@@ -577,7 +577,7 @@
 
                 if (protoSelect.innerHTML === '') {
                     const opt = document.createElement('option');
-                    opt.textContent = 'Нет протоколов';
+                    opt.textContent = _('no_protocols');
                     opt.disabled = true;
                     protoSelect.appendChild(opt);
                     hideConnectionsSection();
@@ -591,13 +591,13 @@
                 }
             }
             updateStatusCounts(data.protocols || {});
-            showToast('Проверка завершена', 'success');
+            showToast(_('check_done'), 'success');
         } catch (err) {
-            showToast('Ошибка: ' + err.message, 'error');
+            showToast(_('error') + ': ' + err.message, 'error');
             const statusDiv = document.getElementById('serverStatus');
             const badges = document.getElementById('statusBadges');
             statusDiv.classList.remove('hidden');
-            badges.innerHTML = `<span class="badge badge-danger"><span class="badge-dot"></span> Ошибка подключения</span>`;
+            badges.innerHTML = `<span class="badge badge-danger"><span class="badge-dot"></span> ${_('check_error')}</span>`;
         } finally {
             btn.disabled = false;
             text.textContent = _('server_check');
@@ -726,7 +726,7 @@
             // Recheck after a short delay
             setTimeout(() => checkServer(), 1500);
         } catch (err) {
-            showToast('Ошибка: ' + err.message, 'error');
+            showToast(_('error') + ': ' + err.message, 'error');
         }
     }
 
@@ -742,7 +742,7 @@
             serverConfigFilename = `server_${proto}.conf`;
             openModal('serverConfigModal');
         } catch (err) {
-            showToast('Ошибка: ' + err.message, 'error');
+            showToast(_('error') + ': ' + err.message, 'error');
         }
     }
 
@@ -793,7 +793,7 @@
     function openInstallModal(proto) {
         currentInstallProto = proto;
         const name = getProtoTitle(proto);
-        document.getElementById('installModalTitle').textContent = `Установить ${name}`;
+            document.getElementById('installModalTitle').textContent = `${_('install')} ${name}`;
 
         const portInput = document.getElementById('installPort');
         const portLabel = document.getElementById('installPortLabel');
@@ -806,7 +806,7 @@
             portLabel.textContent = _('port') + ' (Internal)';
             portInput.value = '53';
             portInput.disabled = true;
-            portHint.textContent = 'Сервис будет запущен во внутренней сети (172.29.172.254) без привязки к портам хоста.';
+            portHint.textContent = _('internal_network_hint');
         } else if (proto === 'xray') {
             portLabel.textContent = _('port') + ' (TCP)';
             portInput.disabled = false;
@@ -898,7 +898,7 @@
             showToast(`${name} ${_('stopped')}`, 'success');
             setTimeout(() => window.location.reload(), 800);
         } catch (err) {
-            showToast('Ошибка: ' + err.message, 'error');
+            showToast(_('error') + ': ' + err.message, 'error');
         }
     }
 
@@ -990,7 +990,7 @@
             });
         } catch (err) {
             loading.style.display = 'none';
-            showToast('Ошибка загрузки подключений: ' + err.message, 'error');
+            showToast(_('loading_connections_error') + ': ' + err.message, 'error');
         }
     }
 
@@ -1016,7 +1016,7 @@
             }
             const result = await apiCall(isEditingConn ? `/api/servers/${SERVER_ID}/connections/edit` : `/api/servers/${SERVER_ID}/connections/add`, 'POST', params);
             if (isEditingConn) {
-                showToast('Подключение обновлено', 'success');
+                showToast(_('connection_updated'), 'success');
                 closeModal('addConnectionModal');
             } else {
                 showToast(_('connection_created').replace('{}', connName), 'success');
@@ -1039,10 +1039,10 @@
             }
             loadConnections();
         } catch (err) {
-            showToast('Ошибка: ' + err.message, 'error');
+            showToast(_('error') + ': ' + err.message, 'error');
         } finally {
             btn.disabled = false;
-            text.textContent = 'Создать';
+            text.textContent = _('create');
             spinner.classList.add('hidden');
         }
     }
@@ -1055,8 +1055,8 @@
         const proto = document.getElementById('connProtoSelect').value;
         const telemtOpts = document.getElementById('telemtConnOptions');
 
-        document.getElementById('addConnectionModalTitle').textContent = isEdit ? 'Редактировать подключение' : 'Добавить подключение';
-        document.getElementById('addConnBtnText').textContent = isEdit ? 'Сохранить' : 'Создать';
+        document.getElementById('addConnectionModalTitle').textContent = isEdit ? _('edit_connection') : _('add_connection');
+        document.getElementById('addConnBtnText').textContent = isEdit ? _('save') : _('create');
         document.getElementById('connectionNameGroup').style.display = isEdit ? 'none' : 'block';
 
         if (proto === 'telemt' && isEdit) {
@@ -1095,7 +1095,7 @@
             showToast(_('connection_deleted'), 'success');
             loadConnections();
         } catch (err) {
-            showToast('Ошибка: ' + err.message, 'error');
+            showToast(_('error') + ': ' + err.message, 'error');
         }
     }
 
@@ -1144,22 +1144,21 @@
                 generateQR(result.config);
             }
         } catch (err) {
-            showToast('Ошибка: ' + err.message, 'error');
+            showToast(_('error') + ': ' + err.message, 'error');
         }
     }
 
     async function toggleConnection(clientId, enable) {
         const proto = document.getElementById('connProtoSelect').value;
-        const action = enable ? 'Включить' : 'Отключить';
         try {
-            showToast(`${action} подключение...`, 'info');
+            showToast(_('connection_enabled_disabled').replace('{status}', enable ? _('enabling') : _('disabling')) + '...', 'info');
             await apiCall(`/api/servers/${SERVER_ID}/connections/toggle`, 'POST', {
                 protocol: proto, client_id: clientId, enable: enable,
             });
-            showToast(`Подключение ${enable ? 'включено' : 'отключено'}`, 'success');
+            showToast(_('connection_enabled_disabled').replace('{status}', enable ? _('enabled') : _('disabled')), 'success');
             loadConnections();
         } catch (err) {
-            showToast('Ошибка: ' + err.message, 'error');
+            showToast(_('error') + ': ' + err.message, 'error');
         }
     }
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -330,5 +330,10 @@
     "setup_complete": "Setup complete! Redirecting...",
     "setup_already_done": "Setup already completed",
     "setup_username_invalid": "Username must be 3-32 characters (letters, numbers, underscores)",
-    "setting_up": "Setting up..."
+    "setting_up": "Setting up...",
+    "loading_connections_error": "Failed to load connections",
+    "connection_updated": "Connection updated",
+    "connection_enabled_disabled": "Connection {status}",
+    "enabled": "Enabled",
+    "edit_connection": "Edit connection"
 }

--- a/translations/fa.json
+++ b/translations/fa.json
@@ -292,5 +292,10 @@
     "setup_complete": "Setup complete! Redirecting...",
     "setup_already_done": "Setup already completed",
     "setup_username_invalid": "Username must be 3-32 characters (letters, numbers, underscores)",
-    "setting_up": "Setting up..."
+    "setting_up": "Setting up...",
+    "loading_connections_error": "خطا در بارگذاری اتصالات",
+    "connection_updated": "اتصال به‌روز شد",
+    "connection_enabled_disabled": "اتصال {status}",
+    "enabled": "فعال",
+    "edit_connection": "ویرایش اتصال"
 }

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -292,5 +292,10 @@
     "setup_complete": "Setup complete! Redirecting...",
     "setup_already_done": "Setup already completed",
     "setup_username_invalid": "Username must be 3-32 characters (letters, numbers, underscores)",
-    "setting_up": "Setting up..."
+    "setting_up": "Setting up...",
+    "loading_connections_error": "Échec du chargement des connexions",
+    "connection_updated": "Connexion mise à jour",
+    "connection_enabled_disabled": "Connexion {status}",
+    "enabled": "Activé",
+    "edit_connection": "Modifier la connexion"
 }

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -330,5 +330,10 @@
     "setup_complete": "Настройка завершена! Перенаправление...",
     "setup_already_done": "Настройка уже завершена",
     "setup_username_invalid": "Имя пользователя должно быть 3-32 символа (буквы, цифры, подчеркивания)",
-    "setting_up": "Настройка..."
+    "setting_up": "Настройка...",
+    "loading_connections_error": "Ошибка загрузки подключений",
+    "connection_updated": "Подключение обновлено",
+    "connection_enabled_disabled": "Подключение {status}",
+    "enabled": "Включено",
+    "edit_connection": "Редактировать подключение"
 }

--- a/translations/zh.json
+++ b/translations/zh.json
@@ -292,5 +292,10 @@
     "setup_complete": "Setup complete! Redirecting...",
     "setup_already_done": "Setup already completed",
     "setup_username_invalid": "Username must be 3-32 characters (letters, numbers, underscores)",
-    "setting_up": "Setting up..."
+    "setting_up": "Setting up...",
+    "loading_connections_error": "加载连接失败",
+    "connection_updated": "连接已更新",
+    "connection_enabled_disabled": "连接{status}",
+    "enabled": "已启用",
+    "edit_connection": "编辑连接"
 }


### PR DESCRIPTION
## What
Replace 13 hardcoded Russian strings in `templates/server.html` with i18n `_()` calls.
Fix `app.py` rate limit handler to use `_get_default_lang()` instead of hardcoded `"ru"`.

## Why
Issue #69: Users selecting English or other languages still saw Russian text in
connection check/error/modals (e.g., "Проверка завершена", "Ошибка загрузки подключений").
The rate limit handler also defaulted to Russian (`"ru"`) regardless of user preference.

## Technical approach
- 13 JS toast/label strings in `server.html` replaced with `_("key")` calls
- `_()` function inherited from `base.html` via `window._` (falls back to key name if translation missing)
- `connection_enabled_disabled` uses `.replace("{status}", ...)` with trusted i18n values — no XSS risk
- `app.py` line 72: `request.cookies.get("lang", "ru")` → `request.cookies.get("lang", _get_default_lang())`
- 4 new keys in all 5 language files (en, ru, fr, zh, fa)

## Testing
- 729 tests pass, 75 pre-existing failures (zero new)
- Black + flake8 clean
- All 5 translation JSONs parse successfully
- Zero targeted Cyrillic strings remain in server.html JS
- QA APPROVED by qa_bot (8/8 acceptance criteria met)

Non-blocking note: 3 Cyrillic strings remain in server.html (lines 818, 846, 1029)
outside the scope of this task (port hint, install log, config modal title).

Closes #69