### PR TITLE
fix: setup wizard CSRF token missing + redirect loop (#185)

### DIFF
--- a/templates/setup.html
+++ b/templates/setup.html
@@ -275,9 +275,12 @@
                     throw new Error(_('passwords_dont_match'));
                 }
 
+                const meta = document.querySelector('meta[name="csrf-token"]');
+                const csrfToken = meta ? meta.getAttribute('content') : (document.cookie.match(/csrftoken=([^;]+)/)?.[1] || '');
+
                 const res = await fetch('/api/auth/setup', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
                     body: JSON.stringify({
                         username: username,
                         password: password,
@@ -294,7 +297,7 @@
 
                 // Redirect to dashboard after short delay
                 setTimeout(() => {
-                    window.location.href = '/';
+                    window.location.href = '/login';
                 }, 1500);
             } catch (err) {
                 errEl.textContent = err.message;

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -257,6 +257,124 @@ class TestSetupAPI:
         # Verify the rate limit decorator is present
         assert "limiter.limit" in source, "Rate limit decorator not found on setup endpoint"
 
+    def test_setup_api_without_csrf_fails(self):
+        """POST /api/auth/setup without X-CSRF-Token header must return 403.
+
+        In a real browser, GET /setup loads the form AND sets both 'session' and
+        'csrftoken' cookies. When the user submits the form, both cookies are sent.
+        The CSRF middleware with sensitive_cookies={"session"} sees the session cookie
+        but no X-CSRF-Token header and returns 403.
+
+        This test simulates that exact scenario: session + csrftoken cookies present
+        (simulating browser state), but X-CSRF-Token header intentionally omitted.
+        """
+        from app import app
+
+        client = TestClient(app)
+
+        # Step 1: GET /setup to load the form and establish both session + csrftoken cookies.
+        # follow_redirects=True hits the middleware chain: GET / → setup_redirect → /setup
+        # After this, the client has both session (from the redirect chain) and csrftoken cookies.
+        get_resp = client.get("/setup", follow_redirects=True)
+        assert get_resp.status_code == 200
+
+        # Step 2: Verify both cookies are present on the client.
+        # session cookie should have been set during the redirect chain.
+        # csrftoken should be set by the CSRF middleware on the /setup response.
+        session_cookie = client.cookies.get("session")
+        csrf_cookie = client.cookies.get("csrftoken")
+
+        # Re-fetch from /setup to ensure csrftoken is fresh if not present
+        if not csrf_cookie:
+            get_resp2 = client.get("/setup", follow_redirects=False)
+            for header_value in get_resp2.headers.get_list("set-cookie"):
+                if header_value.startswith("csrftoken="):
+                    csrf_cookie = header_value.split("csrftoken=")[1].split(";")[0]
+                    client.cookies.set("csrftoken", csrf_cookie)
+                    break
+
+        # We need the session cookie for CSRF enforcement; if missing, create a minimal session
+        if not session_cookie:
+            client.cookies.set("session", "test-session-for-csrf")
+
+        # Re-fetch csrftoken now that we have a session
+        get_resp3 = client.get("/setup", follow_redirects=False)
+        for header_value in get_resp3.headers.get_list("set-cookie"):
+            if header_value.startswith("csrftoken="):
+                csrf_cookie = header_value.split("csrftoken=")[1].split(";")[0]
+                client.cookies.set("csrftoken", csrf_cookie)
+                break
+
+        # Step 3: POST WITHOUT the X-CSRF-Token header, but WITH both session + csrftoken cookies.
+        # This is exactly what happens in the buggy browser when setup.html doesn't read/send the token.
+        response = client.post(
+            "/api/auth/setup",
+            json={
+                "username": "csrf_test_admin",
+                "password": "SecurePass1",
+                "confirm_password": "SecurePass1",
+            },
+            # NOTE: no headers={"x-csrf-token": ...} — that's the bug we're testing
+        )
+        assert response.status_code == 403, (
+            f"Expected 403 (CSRF rejection) but got {response.status_code}. "
+            "CSRF middleware should reject POST with session cookie but no X-CSRF-Token header."
+        )
+
+    def test_setup_redirect_chain_no_loop(self):
+        """After successful setup, redirect to /login then / (no redirect loop).
+
+        Bug #185: Previously setup.html redirected to '/' directly. The 401
+        exception handler redirects HTML requests to /login, causing a loop:
+          / → 401 → /login → (session has user_id) → / → 401 → /login → ...
+
+        Fix: setup.html now redirects to /login. With a valid session, GET /login
+        hits the `if user: return RedirectResponse(url="/", status_code=302)` check
+        and redirects to '/' once, breaking the loop.
+        """
+        from app import app
+
+        client = TestClient(app)
+
+        # Perform setup — use GET /setup first so middleware sets up session/csrtoken
+        setup_get = client.get("/setup", follow_redirects=True)
+        assert setup_get.status_code == 200
+
+        # Extract CSRF token and send properly-authenticated POST
+        csrf_token = None
+        for header_value in setup_get.headers.get_list("set-cookie"):
+            if "csrftoken=" in header_value:
+                csrf_token = header_value.split("csrftoken=")[1].split(";")[0]
+                break
+
+        headers = {}
+        if csrf_token:
+            client.cookies.set("csrftoken", csrf_token)
+            headers["x-csrf-token"] = csrf_token
+
+        setup_post = client.post(
+            "/api/auth/setup",
+            headers=headers,
+            json={
+                "username": "loop_test_admin",
+                "password": "SecurePass1",
+                "confirm_password": "SecurePass1",
+            },
+        )
+        assert (
+            setup_post.status_code == 200
+        ), f"Setup POST failed with {setup_post.status_code}: {setup_post.text}"
+
+        # After setup, session should have user_id set
+        # (TestClient preserves cookies across requests via cookies jar)
+        response_login = client.get("/login", follow_redirects=False)
+        assert response_login.status_code == 302
+        assert response_login.headers["location"] == "/"
+
+        # Following that redirect should succeed without a loop
+        response_home = client.get("/", follow_redirects=False)
+        assert response_home.status_code == 200
+
 
 # ======================== Middleware Tests ========================
 


### PR DESCRIPTION
## What
Fix two bugs in the setup wizard that cause ERR_TOO_MANY_REDIRECTS on first launch.

## Why
- **Bug 1 (P1):** `setup.html` JS fetch() was missing the `X-CSRF-Token` header. After GET `/setup` sets session + csrftoken cookies, the POST `/api/auth/setup` gets rejected with 403 by the CSRF middleware. Admin user is never created.
- **Bug 2:** After setup, JS redirected to `/` which triggers the 401 handler → `/login` → session user detected → `/` → 401 → loop.

## Technical approach
- Added CSRF token extraction + `X-CSRF-Token` header to setup.html fetch() (same pattern as login.html)
- Changed post-setup redirect from `/` to `/login` — `/login` with a valid session redirects cleanly to `/` via login_page's `if user:` check

## Testing
816 tests pass, black + flake8 clean. 14 setup wizard tests pass. QA APPROVED by qa_bot.

Closes #185