### PR TITLE
fix: Starlette 1.0 TemplateResponse compatibility

### DIFF
--- a/app/utils/templates.py
+++ b/app/utils/templates.py
@@ -34,4 +34,4 @@ def tpl(request, template, **kwargs):
         "csrf_token": request.cookies.get("csrftoken", ""),
     }
     ctx.update(kwargs)
-    return templates.TemplateResponse(template, ctx)
+    return templates.TemplateResponse(request, template, ctx)


### PR DESCRIPTION
## Fix: Starlette 1.0 TemplateResponse Compatibility

Starlette 1.0.0 changed `Jinja2Templates.TemplateResponse` signature from `TemplateResponse(name, context)` to `TemplateResponse(request, name, context)`. The `request` parameter is now required as the first positional argument.

### Change
- `app/utils/templates.py:37`: Updated `templates.TemplateResponse(template, ctx)` → `templates.TemplateResponse(request, template, ctx)`

### Test Results
- 817/817 tests pass with starlette 1.0.0 + anyio 4.13.0
- Without this fix, 62 tests fail with `TypeError: unhashable type: 'dict'`

### Context
Dependabot PRs #180 (starlette 1.0.0) and #183 (anyio 4.13.0) were merged but broke the codebase. This PR adds the compatibility fix on top of those merges.