### PR TITLE
fix: update site-packages path to python3.14 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ FROM python:3.14-slim
 WORKDIR /app
 
 # Copy installed site-packages from builder stage
-COPY --from=builder /usr/local/lib/python3.13/site-packages/ /usr/local/lib/python3.13/site-packages/
+COPY --from=builder /usr/local/lib/python3.14/site-packages/ /usr/local/lib/python3.14/site-packages/
 
 # Copy pip entry-points / scripts from builder (gunicorn, uvicorn, etc.)
 COPY --from=builder /usr/local/bin/ /usr/local/bin/


### PR DESCRIPTION
## Fix: Dockerfile site-packages path for Python 3.14

PR #179 updated the base image from `python:3.13-slim` to `python:3.14-slim`, but the `COPY --from=builder` line still referenced the `python3.13` site-packages path, causing the Docker build to fail:

```
failed to calculate checksum: "/usr/local/lib/python3.13/site-packages": not found
```

### Change
- Line 23: `/usr/local/lib/python3.13/site-packages/` → `/usr/local/lib/python3.14/site-packages/`

### CI Failure
Fixes the build failure in [run 25457191596](https://github.com/devops-igor/amnezia-web-ui/actions/runs/25457191596/job/74689702110).