### PR TITLE
fix: bump python-multipart 0.0.27 for CVE-2026-42561

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ Pygments==2.20.0
 PyNaCl==1.6.2
 pyparsing==3.3.2
 python-dotenv==1.2.2
-python-multipart==0.0.26
+python-multipart==0.0.27
 PyYAML==6.0.3
 requests==2.33.1
 rich==14.3.3


### PR DESCRIPTION
Bumps python-multipart from 0.0.26 to 0.0.27 to fix CVE-2026-42561.

This fixes the pip-audit failure in the CI security workflow.