### PR TITLE
fix: rename modal hidden class (#192)

### DIFF
--- a/templates/my_connections.html
+++ b/templates/my_connections.html
@@ -143,7 +143,7 @@
 </div>
 
 <!-- Rename Modal -->
-<div class="modal-backdrop hidden" id="renameModal">
+<div class="modal-backdrop" id="renameModal">
     <div class="modal" style="max-width: 400px;">
         <div class="modal-header">
             <h2 class="modal-title">{{ _('rename_connection') }}</h2>


### PR DESCRIPTION
Fixes the rename connection modal not opening when clicking the ✏️ Rename button.

The `renameModal` div had `class="modal-backdrop hidden"` but the `openModal()` function only adds `active` class — it never removes `hidden`. The other modals (`configModal`, `createConnModal`) use `class="modal-backdrop"` without `hidden`, relying solely on the `active` class for visibility.

Fix: Remove `hidden` from the class attribute so `openModal("renameModal")` works the same as the other modals.