### PR TITLE
fix: make client-actions buttons inline (#192)

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -906,8 +906,7 @@ button:focus-visible,
     gap: var(--space-sm);
     flex-shrink: 0;
     margin-left: var(--space-md);
-    flex-wrap: wrap;
-    max-width: 140px;
+    flex-wrap: nowrap;
 }
 
 /* ===== Config Display ===== */


### PR DESCRIPTION
The Rename and Show config buttons on the My Connections page were stacking vertically because `.client-actions` had `max-width: 140px` and `flex-wrap: wrap`. Changed to `flex-wrap: nowrap` and removed `max-width` so buttons stay inline side-by-side.

This matches the pattern already used by the server.html override (`flex-direction: row !important; flex-wrap: nowrap !important`), but now in the shared CSS so all pages benefit.