### PR TITLE
chore: add TASKS_OVERVIEW.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ VERIFICATION_REPORT*.md
 .secret_key
 =0.9.0
 tests/e2e/screenshots/
+TASKS_OVERVIEW.md


### PR DESCRIPTION
## What
Add `TASKS_OVERVIEW.md` to `.gitignore` to prevent the local task tracking file from being accidentally committed.

## Why
`TASKS_OVERVIEW.md` is a local pm_bot work file that tracks issue status. It was included in commit 757f6d9 (PR #202) by mistake. While the content differences between PR #200 and #202 are limited to this file, it should not be tracked in the repository.

## Testing
- Verified: `git status` shows clean working tree
- `TASKS_OVERVIEW.md` is now ignored by git