### PR TITLE
fix: make DATA_DIR configurable via env var for Docker volume mounts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,8 +23,11 @@ SECRET_KEY=<generate-with-command-above>
 AMNEZIA_IMAGE=ghcr.io/devops-igor/amnezia-web-ui:latest
 
 # Port for direct panel access (bypasses BunkerWeb).
-# Set to empty (APP_PORT=) to disable when using BunkerWeb profile.
-# In that case, BunkerWeb handles all HTTP on port 80/443.
+# When using BunkerWeb profile, set APP_PORT= (empty) so the panel
+# is only accessible through BunkerWeb. Note: Docker Compose treats
+# an empty APP_PORT as a random ephemeral host port, not "no port".
+# The panel will still be reachable on that random port from the host.
+# For true isolation, rely on BunkerWeb as the sole entry point.
 APP_PORT=5000
 
 # Directory on the host for persistent panel data ( SQLite DB, etc. )

--- a/config.py
+++ b/config.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 # ======================== Paths ========================
 
-DATA_DIR = os.path.dirname(os.path.abspath(__file__))
+DATA_DIR = os.environ.get("DATA_DIR", os.path.dirname(os.path.abspath(__file__)))
 DB_PATH = os.path.join(DATA_DIR, "panel.db")
 
 # ======================== SECRET_KEY ========================

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,10 @@ services:
     image: ${AMNEZIA_IMAGE:-ghcr.io/devops-igor/amnezia-web-ui:latest}
     container_name: amnezia-panel
     # Expose panel port directly. Set APP_PORT= (empty) in .env when using
-    # BunkerWeb to disable this port mapping — BunkerWeb routes traffic instead.
+    # BunkerWeb to skip direct port exposure — BunkerWeb routes traffic instead.
+    # NOTE: Docker treats APP_PORT= as a random ephemeral host port (:5000),
+    # not "no port". To fully block direct access, use firewall rules or rely
+    # on BunkerWeb as the sole entry point.
     ports:
       - "${APP_PORT:-5000}:5000"
     restart: unless-stopped
@@ -38,6 +41,7 @@ services:
     environment:
       - SECRET_KEY=${SECRET_KEY:?SECRET_KEY must be set in .env}
       - TRUSTED_PROXIES=${TRUSTED_PROXIES:-172.18.0.0/24}
+      - DATA_DIR=/app/data
     networks:
       - bw-net
     # NOTE: No depends_on for bunkerweb here. When running with --profile bunkerweb,

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -148,7 +148,7 @@ USE_WHITELIST_IP=yes
 WHITELIST_IP_LIST=203.0.113.50,203.0.113.100
 ```
 
-> **Security**: `APP_PORT=` (empty) disables direct panel access, forcing all traffic through BunkerWeb. This prevents bypassing the WAF.
+> **Security note**: When `APP_PORT=` (empty), Docker Compose still maps a random ephemeral host port to container port 5000. This means the panel may still be reachable from the host on an unpredictable port. For true isolation, rely on BunkerWeb as your sole entry point and use host firewall rules (`ufw`) to restrict direct access.
 
 ### Step 4 — Start the Stack
 
@@ -215,7 +215,7 @@ Telemt is available at `http://localhost:18443` (standalone) or via the reverse 
 |----------|---------|----------|-------------|
 | `SECRET_KEY` | — | **Yes** | Session signing key. Generate with `python3 -c "import secrets; print(secrets.token_hex(32))"` |
 | `AMNEZIA_IMAGE` | `ghcr.io/devops-igor/amnezia-web-ui:latest` | No | Docker image tag. Pin to a version tag or SHA in production |
-| `APP_PORT` | `5000` | No | Direct panel port. Set empty (`APP_PORT=`) to disable when using BunkerWeb |
+| `APP_PORT` | `5000` | No | Direct panel port. Note: `APP_PORT=` (empty) maps a random ephemeral port due to Docker behavior, not "no port". Use BunkerWeb + firewall for true isolation |
 | `DATA_DIR` | `./data` | No | Host directory for panel SQLite DB and config persistence |
 | `TRUSTED_PROXIES` | `172.18.0.0/24` | No | CIDR list of trusted proxies for X-Forwarded-For resolution |
 | `SERVER_NAME` | `localhost` | No | Primary domain for BunkerWeb vhost and Let's Encrypt |
@@ -348,7 +348,7 @@ ufw allow 443/tcp
 ufw enable
 ```
 
-> Do NOT expose port 5000 directly in production unless you fully understand the security implications. When using BunkerWeb, set `APP_PORT=` in `.env`.
+> Do NOT expose port 5000 directly in production unless you fully understand the security implications. When using BunkerWeb, set `APP_PORT=` in `.env` — but note that Docker may still map a random ephemeral host port. Use host firewall rules (`ufw`) to restrict direct access if needed.
 
 ### SSH Hardening
 


### PR DESCRIPTION
## What

Make `DATA_DIR` configurable via environment variable so the panel writes `panel.db` into the mounted Docker volume instead of the read-only rootfs.

Also documents that `APP_PORT=` (empty string) maps a random ephemeral host port in Docker Compose, not "no port".

## Why

During clean deployment testing of #197 (docker-compose-upgrade), two bugs were found:

**BUG #1 (Critical):** `read_only: true` + hardcoded `DATA_DIR` causes panel crash
- `config.py` hardcoded `DATA_DIR = os.path.dirname(os.path.abspath(__file__))` = `/app/`
- `panel.db` was written to `/app/panel.db` inside the read-only rootfs
- Container entered restart loop with `sqlite3.OperationalError: unable to open database file`

**BUG #2 (Documentation):** `APP_PORT=` empty string misleading
- `.env.example` said "Set to empty to disable" but Docker Compose treats `APP_PORT=` as a random ephemeral port
- Panel was still directly accessible, bypassing BunkerWeb security

## Technical approach

1. **config.py line 16:** `DATA_DIR = os.environ.get("DATA_DIR", os.path.dirname(os.path.abspath(__file__)))` - reads env var with fallback
2. **docker-compose.yml:** Added `DATA_DIR=/app/data` environment variable to amnezia-panel service
3. **docker-compose.yml:** Added NOTE comment about Docker APP_PORT= behavior
4. **.env.example:** Corrected APP_PORT documentation
5. **docs/deployment.md:** Updated 3 locations with accurate APP_PORT and security notes

## Testing

- 841 tests pass (full suite)
- black --check . clean
- flake8 . clean
- Clean deployment test on dev server across 8 phases
- QA APPROVED by qa_bot