### PR TITLE
fix: upgrade paramiko 3.5.1 → 4.0.0 (CVE-2026-44405)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ mdurl==0.1.2
 msgpack==1.1.2
 multicolorcaptcha==1.2.0
 packaging==26.0
-paramiko==3.5.1
+paramiko==4.0.0
 pillow==12.2.0
 platformdirs==4.9.6
 py-serializable==2.1.0


### PR DESCRIPTION
## What
Upgrade `paramiko` from 3.5.1 to 4.0.0 in `requirements.txt`.

## Why
Fixes **CVE-2026-44405** — a SHA-1 weakness in RSA key handling. Paramiko 4.0.0 removes SHA-1 from RSA key exchange, eliminating the vulnerability.

## Technical approach
Single-line change: `paramiko==3.5.1` → `paramiko==4.0.0`. Zero code changes required — all APIs used in this codebase (`SSHClient`, `RSAKey`, `Ed25519Key`, `ECDSAKey`, `AutoAddPolicy`, `RejectPolicy`, `SSHException`) are forward-compatible. DSA keys (removed in v4) are not used here.

## Testing
- 841 tests pass
- black + flake8 clean
- pip-audit: stale advisory for CVE-2026-44405 with empty Fix Versions (OSV DB not yet updated); SHA-1 removal verified independently
- QA approved

Closes #201