### PR TITLE
fix: use APP_DIR for translations instead of DATA_DIR

### DIFF
--- a/config.py
+++ b/config.py
@@ -13,7 +13,11 @@ logger = logging.getLogger(__name__)
 
 # ======================== Paths ========================
 
-DATA_DIR = os.environ.get("DATA_DIR", os.path.dirname(os.path.abspath(__file__)))
+# APP_DIR: directory of config.py — static app files (translations, etc.)
+# DATA_DIR: directory for writable runtime data (DB, secrets) — defaults to APP_DIR
+#           but can be overridden for Docker volumes (e.g. DATA_DIR=/app/data)
+APP_DIR = os.path.dirname(os.path.abspath(__file__))
+DATA_DIR = os.environ.get("DATA_DIR", APP_DIR)
 DB_PATH = os.path.join(DATA_DIR, "panel.db")
 
 # ======================== SECRET_KEY ========================
@@ -71,7 +75,7 @@ TRANSLATIONS: dict = {}
 
 
 def load_translations():
-    trans_dir = os.path.join(DATA_DIR, "translations")
+    trans_dir = os.path.join(APP_DIR, "translations")
     if os.path.exists(trans_dir):
         for f in os.listdir(trans_dir):
             if f.endswith(".json"):


### PR DESCRIPTION
## Bug

PR #210 introduced `DATA_DIR=/app/data` as an env var override for Docker volume mounts. However, `load_translations()` was also using `DATA_DIR` to locate the `translations/` directory, which is a **static app directory** baked into the Docker image at `/app/translations/`.

With `DATA_DIR=/app/data`, translations were looked for in `/app/data/translations/` (which doesn't exist), causing all i18n strings to render as raw key names instead of translated text. The setup wizard showed `setup_title` instead of "Initial Setup", etc.

## Fix

Introduce `APP_DIR` (the directory of config.py, always `/app/` in Docker) for **static app files**, and keep `DATA_DIR` for **writable runtime data** (DB, secret key). `load_translations()` now uses `APP_DIR`.

## Files Changed

- `config.py`: Added `APP_DIR` constant, changed `load_translations()` to use `APP_DIR` instead of `DATA_DIR`

## Verification

- 841 tests pass
- black + flake8 clean
- `APP_DIR=/path/to/project DATA_DIR=/tmp/test` loads translations correctly from APP_DIR
- DB path correctly uses DATA_DIR: `/tmp/test/panel.db`

## Impact

- `migrate_to_sqlite.migrate_if_needed(DATA_DIR)` correctly still uses DATA_DIR (migrates data from the writable volume)
- `.secret_key` correctly still uses DATA_DIR (writable volume)
- Only the translation lookup path changed