### PR TITLE
fix: Telemt live verification bugs + deployment docs improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,9 @@ TRUSTED_PROXIES=172.18.0.0/24
 # For a single domain:   SERVER_NAME=vpn.example.com
 # For multiple domains:  SERVER_NAME=vpn.example.com panel.example.com
 # Space-separated. BunkerWeb will request a Let's Encrypt cert for each.
+# IMPORTANT: When using multiple domains, BunkerWeb autoconf only maps
+# REVERSE_PROXY_HOST to the FIRST domain. Additional domains need per-site
+# labels in docker-compose.yml (see the bunkerweb service comments).
 SERVER_NAME=localhost
 
 # Enable Let's Encrypt automatic certificate generation.

--- a/app/managers/telemt_manager.py
+++ b/app/managers/telemt_manager.py
@@ -275,8 +275,17 @@ class TelemtManager:
 
         config_content = re.sub(r"public_port\s*=\s*\d+", f"public_port = {port}", config_content)
 
-        # Remove default hello user
-        config_content = re.sub(r'^hello\s*=\s*".*?"', "", config_content, flags=re.MULTILINE)
+        # Replace default hello user with a generated admin user.
+        # Telemt requires at least one user in [access.users] to start —
+        # without it, the container crash-loops with
+        # "Invalid config: No users configured".
+        admin_secret = secrets.token_hex(16)
+        config_content = re.sub(
+            r'^hello\s*=\s*".*?"',
+            f'admin = "{admin_secret}"',
+            config_content,
+            flags=re.MULTILINE,
+        )
 
         # Log the hash of the patched content for audit trail
         patched_hash = hashlib.sha256(config_content.encode("utf-8")).hexdigest()
@@ -323,9 +332,11 @@ class TelemtManager:
 
     def remove_container(self, protocol_type: Optional[str] = None) -> None:
         """Remove the Telemt container using compose profile."""
-        # Stop and remove the telemt service via compose profile
+        # Stop and remove the telemt service via compose profile.
+        # NOTE: Do NOT use --remove-orphans, as the panel container is
+        # defined in the same compose file. --remove-orphans would kill it.
         out, err, code = self.ssh.run_sudo_command(
-            f"cd {self._compose_dir()} && docker compose --profile telemt down --remove-orphans",
+            f"cd {self._compose_dir()} && docker compose --profile telemt down",
             timeout=60,
         )
         if code != 0:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,12 +87,15 @@ services:
       - AUTOCONF_MODE=yes
 
       # NOTE: When using multiple domains in SERVER_NAME (e.g. "vpn.example.com panel.example.com"),
-      # BunkerWeb autoconf only maps REVERSE_PROXY_HOST to the FIRST domain. For additional
-      # domains, add per-site environment variables here:
-      #   - <domain>_USE_REVERSE_PROXY=yes
-      #   - <domain>_REVERSE_PROXY_HOST=http://amnezia-panel:5000
-      #   - <domain>_REVERSE_PROXY_URL=/
-      #   - <domain>_REVERSE_PROXY_INTERCEPT_ERRORS=no
+      # BunkerWeb autoconf only maps REVERSE_PROXY_HOST to the FIRST domain. For each additional
+      # domain, you must add per-site environment variables on this service:
+      #   - vpn.example.com_USE_REVERSE_PROXY=yes
+      #   - vpn.example.com_REVERSE_PROXY_HOST=http://amnezia-panel:5000
+      #   - vpn.example.com_REVERSE_PROXY_URL=/
+      #   - vpn.example.com_REVERSE_PROXY_INTERCEPT_ERRORS=no
+      #
+      # Without these, additional domains will get a TLS certificate but return 404.
+      # See: https://docs.bunkerweb.io/latest/settings/#multisite
 
       - DOCKER_HOST=tcp://docker-proxy:2375
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -64,8 +64,10 @@ Use this for single-node local testing or development. No domain, no SSL, no WAF
 git clone https://github.com/devops-igor/amnezia-web-ui.git
 cd amnezia-web-ui
 
-# 2. Create environment file
+# 2. Create environment and data directories
 cp .env.example .env
+mkdir -p data
+chown 100:101 data
 
 # 3. Generate a secret key
 SECRET_KEY=$(python3 -c "import secrets; print(secrets.token_hex(32))")
@@ -110,10 +112,12 @@ Wait for DNS propagation (TTL depends on your registrar; typically 5–30 minute
 
 ### Step 2 — Prepare Config Directory
 
-Create a data directory for panel persistence:
+Create a data directory for panel persistence and set ownership so the
+container (which runs as `appuser` UID 100, GID 101) can write to it:
 
 ```bash
 mkdir -p data
+chown 100:101 data
 ```
 
 ### Step 3 — Edit `.env`
@@ -206,6 +210,29 @@ docker compose --profile telemt up -d
 ```
 
 Telemt is available at `http://localhost:18443` (standalone) or via the reverse proxy when bunkerweb is active.
+
+---
+
+### Multiple Domains (BunkerWeb Multisite)
+
+When `SERVER_NAME` contains multiple domains (e.g. `SERVER_NAME=vpn.example.com panel.example.com`), BunkerWeb autoconf only maps `REVERSE_PROXY_HOST` to the **first** domain. Additional domains will receive a TLS certificate but return a 404 because they have no reverse proxy config.
+
+To fix this, add per-domain labels to the `bunkerweb` service in `docker-compose.yml`:
+
+```yaml
+    environment:
+      # ... existing env vars ...
+      - vpn.example.com_USE_REVERSE_PROXY=yes
+      - vpn.example.com_REVERSE_PROXY_HOST=http://amnezia-panel:5000
+      - vpn.example.com_REVERSE_PROXY_URL=/
+      - vpn.example.com_REVERSE_PROXY_INTERCEPT_ERRORS=no
+      - panel.example.com_USE_REVERSE_PROXY=yes
+      - panel.example.com_REVERSE_PROXY_HOST=http://amnezia-panel:5000
+      - panel.example.com_REVERSE_PROXY_URL=/
+      - panel.example.com_REVERSE_PROXY_INTERCEPT_ERRORS=no
+```
+
+See [BunkerWeb Multisite Settings](https://docs.bunkerweb.io/latest/settings/#multisite) for details.
 
 ---
 

--- a/tests/test_telemt_manager.py
+++ b/tests/test_telemt_manager.py
@@ -1053,7 +1053,13 @@ class TestInstallProtocolIntegrityChecks:
             config_content,
         )
         config_content = re.sub(r"public_port\s*=\s*\d+", "public_port = 443", config_content)
-        config_content = re.sub(r'^hello\s*=\s*".*?"', "", config_content, flags=re.MULTILINE)
+        # Replace hello user with admin user (matches install_protocol behavior)
+        config_content = re.sub(
+            r'^hello\s*=\s*".*?"',
+            'admin = "00000000000000000000000000000000"',
+            config_content,
+            flags=re.MULTILINE,
+        )
         config_content = re.sub(
             r'#?\s*public_host\s*=\s*".*?"', 'public_host = "10.0.0.1"', config_content
         )
@@ -1066,7 +1072,9 @@ class TestInstallProtocolIntegrityChecks:
             return ("", "", 0)
 
         self.mock_ssh.run_command.side_effect = run_command_side_effect
-        result = self.manager.install_protocol("telemt", port="443")
+        # Mock secrets.token_hex to return deterministic value for admin user
+        with patch("app.managers.telemt_manager.secrets.token_hex", return_value="0" * 32):
+            result = self.manager.install_protocol("telemt", port="443")
         assert result["status"] == "success"
 
     @patch("app.managers.telemt_manager.verify_integrity", return_value=True)
@@ -1198,7 +1206,13 @@ class TestInstallProtocolComposeProfile:
             config_content,
         )
         config_content = re.sub(r"public_port\s*=\s*\d+", "public_port = 443", config_content)
-        config_content = re.sub(r'^hello\s*=\s*".*?"', "", config_content, flags=re.MULTILINE)
+        # Replace hello user with admin user (matches install_protocol behavior)
+        config_content = re.sub(
+            r'^hello\s*=\s*".*?"',
+            'admin = "00000000000000000000000000000000"',
+            config_content,
+            flags=re.MULTILINE,
+        )
         config_content = re.sub(
             r'#?\s*public_host\s*=\s*".*?"', 'public_host = "10.0.0.1"', config_content
         )
@@ -1217,7 +1231,9 @@ class TestInstallProtocolComposeProfile:
             ("", "", 0),
         ]
 
-        self.manager.install_protocol("telemt", port="443")
+        # Mock secrets.token_hex to return deterministic value for admin user
+        with patch("app.managers.telemt_manager.secrets.token_hex", return_value="0" * 32):
+            self.manager.install_protocol("telemt", port="443")
 
         calls = [call[0][0] for call in self.mock_ssh.run_sudo_command.call_args_list]
         compose_calls = [c for c in calls if "docker compose --profile telemt" in c]


### PR DESCRIPTION
## Summary

Bugs found during clean-slate deployment verification on the dev server. Telemt compose profile (#206) was merged without live testing — this PR fixes the issues discovered.

## Bugs Fixed

### 1. CRITICAL: Empty `[access.users]` causes Telemt crash-loop

`install_protocol()` removed the default `hello` user from the config template but didn't add a real admin user. Telemt requires at least one user in `[access.users]` and crash-loops with `"Invalid config: No users configured"`.

**Fix:** Replace `hello = "..."` with `admin = "<random_32_hex_secret>"` using `secrets.token_hex(16)`.

### 2. CRITICAL: `--remove-orphans` kills the panel container

`remove_container()` ran `docker compose --profile telemt down --remove-orphans`. Since the panel and telemt are in the **same compose file**, `--remove-orphans` terminates the panel container too, and the cleanup `rm -rf` of the config directory never executes.

**Fix:** Remove `--remove-orphans` from the compose down command.

### 3. MEDIUM: Missing `chown 100:101` in deployment docs

Fresh `docker compose up` on a clean server creates `data/` owned by root, but the container runs as `appuser` (UID 100). This causes `sqlite3.OperationalError: unable to open database file`.

**Fix:** Added `chown 100:101 data` to both Quick Start and Production steps in `docs/deployment.md`.

### 4. MEDIUM: BunkerWeb multisite 404 on additional domains

With `MULTISITE=yes` and multiple domains in `SERVER_NAME`, only the first domain gets reverse proxy config. Additional domains receive TLS certificates but return 404.

**Fix:** Added detailed documentation in `docker-compose.yml`, `.env.example`, and `deployment.md` explaining the per-domain label requirement.

## Test Results

- 88/88 telemt tests pass
- `black --check` clean
- `flake8` clean
- `py_compile` clean

## Verification

Discovered via full clean-slate deployment test on dev server (207.2.120.44):
1. Wiped all containers, volumes, data
2. Fresh `git clone` → `.env` → `docker compose up`
3. Found DATA_DIR permission bug → added `chown` to docs
4. Found BunkerWeb multisite 404 → documented per-domain labels
5. Added server via UI, installed Telemt → found empty users crash
6. Removed Telemt → found `--remove-orphans` kills panel
7. All issues fixed and re-tested