### PR TITLE
fix: ensure AppArmor utils installed before Docker build on bare systems (#205)

### DIFF
--- a/app/managers/awg_manager.py
+++ b/app/managers/awg_manager.py
@@ -18,7 +18,7 @@ from base64 import b64encode
 from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
 from cryptography.hazmat.primitives import serialization
 
-from docker_utils import check_docker_installed
+from docker_utils import check_docker_installed, ensure_apparmor_utils
 
 logger = logging.getLogger(__name__)
 
@@ -299,6 +299,9 @@ iptables -C FORWARD -j DOCKER-USER 2>/dev/null || iptables -A FORWARD -j DOCKER-
         )
         self.ssh.run_sudo_command(f"mkdir -p {dockerfile_folder}")
         self.ssh.upload_file_sudo(dockerfile_content, f"{dockerfile_folder}/Dockerfile")
+
+        # Ensure AppArmor utils are present (bare systems can fail Docker build otherwise)
+        ensure_apparmor_utils(self.ssh)
 
         out, err, code = self.ssh.run_sudo_command(
             f"docker build --no-cache --pull -t {container_name} {dockerfile_folder}", timeout=300

--- a/app/managers/telemt_manager.py
+++ b/app/managers/telemt_manager.py
@@ -13,7 +13,7 @@ from typing import Any, Optional
 import httpx
 from integrity import IntegrityError, load_expected_hash, verify_integrity
 from app.managers.ssh_manager import SSHManager
-from docker_utils import check_docker_installed
+from docker_utils import check_docker_installed, detect_package_manager
 
 logger = logging.getLogger(__name__)
 
@@ -87,10 +87,12 @@ class TelemtManager:
 
     def _detect_package_manager(self) -> str:
         """Detect the remote server's package manager. Returns 'apt' or 'yum'."""
-        _, _, code = self.ssh.run_command("which apt-get")
-        if code == 0:
-            return "apt"
-        return "yum"
+        result = detect_package_manager(self.ssh)
+        # Map 'dnf' and 'unknown' to 'yum' for Telemt's install commands
+        # (original behavior: yum was the fallback when apt-get wasn't found)
+        if result in ("dnf", "unknown"):
+            return "yum"
+        return result
 
     def check_protocol_installed(self) -> bool:
         """Check if the Telemt container exists on the remote server."""

--- a/app/managers/xray_manager.py
+++ b/app/managers/xray_manager.py
@@ -4,7 +4,7 @@ import logging
 from datetime import datetime
 import urllib.parse
 
-from docker_utils import check_docker_installed
+from docker_utils import check_docker_installed, ensure_apparmor_utils
 
 logger = logging.getLogger(__name__)
 
@@ -120,6 +120,9 @@ ENTRYPOINT [ "dumb-init", "/opt/amnezia/start.sh" ]
 """
         self.ssh.run_sudo_command(f"mkdir -p {dockerfile_folder}")
         self.ssh.upload_file_sudo(dockerfile_content, f"{dockerfile_folder}/Dockerfile")
+
+        # Ensure AppArmor utils are present (bare systems can fail Docker build otherwise)
+        ensure_apparmor_utils(self.ssh)
 
         _, err, code = self.ssh.run_sudo_command(
             f"docker build --no-cache -t {self.IMAGE_NAME} {dockerfile_folder}", timeout=300

--- a/dns_manager.py
+++ b/dns_manager.py
@@ -1,5 +1,7 @@
 import logging
 
+from docker_utils import ensure_apparmor_utils
+
 logger = logging.getLogger(__name__)
 
 
@@ -34,6 +36,9 @@ LABEL maintainer="AmneziaVPN"
 COPY forward-records.conf /opt/unbound/etc/unbound/forward-records.conf
 """
             self.ssh.write_file("/opt/amnezia/dns/Dockerfile", dockerfile)
+
+            # Ensure AppArmor utils are present (bare systems can fail Docker build otherwise)
+            ensure_apparmor_utils(self.ssh)
 
             # 4. Build and run
             self.ssh.run_sudo_command("docker build -t amnezia-dns /opt/amnezia/dns")

--- a/docker_utils.py
+++ b/docker_utils.py
@@ -24,3 +24,56 @@ def check_docker_installed(ssh) -> bool:
         "systemctl is-active docker 2>/dev/null || service docker status 2>/dev/null"
     )
     return "active" in out2 or "running" in out2.lower()
+
+
+def detect_package_manager(ssh) -> str:
+    """Detect the remote server's package manager.
+
+    Returns 'apt', 'yum', 'dnf', or 'unknown'.
+    """
+    _, _, code = ssh.run_command("which apt-get")
+    if code == 0:
+        return "apt"
+    _, _, code = ssh.run_command("which yum")
+    if code == 0:
+        return "yum"
+    _, _, code = ssh.run_command("which dnf")
+    if code == 0:
+        return "dnf"
+    return "unknown"
+
+
+def ensure_apparmor_utils(ssh) -> None:
+    """Ensure apparmor_parser is available if the kernel has AppArmor enabled.
+
+    On minimal/bare Linux systems, AppArmor can be enabled in the kernel
+    but apparmor-parser missing from userspace. This causes Docker builds
+    to fail because Docker tries to load the docker-default AppArmor profile
+    and cannot find apparmor_parser.
+
+    This function checks if apparmor_parser exists; if not, checks if the
+    kernel has AppArmor enabled; if so, installs the apparmor package.
+    """
+    # Check if apparmor_parser is already available
+    _, _, code = ssh.run_command("which apparmor_parser")
+    if code == 0:
+        return  # Already installed, nothing to do
+
+    # Check if kernel has AppArmor enabled
+    out, _, _ = ssh.run_command("cat /sys/module/apparmor/parameters/enabled 2>/dev/null")
+    if "Y" not in out:
+        return  # AppArmor not kernel-enabled, no need to install parser
+
+    # Kernel has AppArmor but parser is missing — install it
+    logger.info(
+        "AppArmor enabled in kernel but apparmor_parser not found. " "Installing apparmor package."
+    )
+    pkg_mgr = detect_package_manager(ssh)
+    if pkg_mgr == "apt":
+        ssh.run_sudo_command("apt-get update -qq && apt-get install -y -qq apparmor")
+    elif pkg_mgr == "yum":
+        ssh.run_sudo_command("yum install -y apparmor")
+    elif pkg_mgr == "dnf":
+        ssh.run_sudo_command("dnf install -y apparmor")
+    else:
+        logger.warning(f"Unsupported package manager for apparmor install: {pkg_mgr}")

--- a/tests/test_awg_manager.py
+++ b/tests/test_awg_manager.py
@@ -669,3 +669,32 @@ class TestAWGManagerConcurrent:
         """The _lock attribute should be a lock instance."""
         assert hasattr(self.manager, "_lock")
         assert self.manager._lock is not None
+
+
+class TestAWGInstallProtocolAppArmor:
+    """Tests that install_protocol calls ensure_apparmor_utils before docker build."""
+
+    def setup_method(self):
+        self.mock_ssh = MagicMock()
+        self.manager = AWGManager(self.mock_ssh)
+
+    def test_install_protocol_calls_ensure_apparmor_utils(self):
+        """install_protocol calls ensure_apparmor_utils before docker build."""
+        # Mock docker installed and protocol not installed
+        with patch("app.managers.awg_manager.check_docker_installed", return_value=True):
+            with patch.object(self.manager, "check_protocol_installed", return_value=False):
+                with patch.object(self.manager, "prepare_host"):
+                    with patch.object(self.manager, "_wait_container_running"):
+                        with patch.object(self.manager, "_configure_container"):
+                            with patch.object(self.manager, "_upload_start_script"):
+                                with patch.object(self.manager, "setup_firewall"):
+                                    self.mock_ssh.run_sudo_command.return_value = ("", "", 0)
+                                    self.mock_ssh.run_command.return_value = ("", "", 0)
+
+                                    with patch(
+                                        "app.managers.awg_manager.ensure_apparmor_utils"
+                                    ) as mock_fn:
+                                        self.manager.install_protocol("awg")
+
+                                        # ensure_apparmor_utils must have been called
+                                        mock_fn.assert_called_once_with(self.mock_ssh)

--- a/tests/test_docker_utils.py
+++ b/tests/test_docker_utils.py
@@ -1,0 +1,161 @@
+"""Unit tests for docker_utils.py — detect_package_manager and ensure_apparmor_utils."""
+
+from unittest.mock import MagicMock, patch
+
+from docker_utils import detect_package_manager, ensure_apparmor_utils
+
+
+class TestDetectPackageManager:
+    """Tests for _detect_package_manager()."""
+
+    def test_detect_package_manager_apt(self):
+        """detect_package_manager returns 'apt' when apt-get is available."""
+        mock_ssh = MagicMock()
+        mock_ssh.run_command.return_value = ("", "", 0)  # which apt-get succeeds
+
+        result = detect_package_manager(mock_ssh)
+
+        assert result == "apt"
+        mock_ssh.run_command.assert_called_once_with("which apt-get")
+
+    def test_detect_package_manager_yum(self):
+        """detect_package_manager returns 'yum' when yum is available and apt-get is not."""
+        mock_ssh = MagicMock()
+        mock_ssh.run_command.side_effect = [
+            ("", "", 1),  # which apt-get fails
+            ("", "", 0),  # which yum succeeds
+        ]
+
+        result = detect_package_manager(mock_ssh)
+
+        assert result == "yum"
+        assert mock_ssh.run_command.call_count == 2
+
+    def test_detect_package_manager_dnf(self):
+        """detect_package_manager returns 'dnf' when only dnf is available."""
+        mock_ssh = MagicMock()
+        mock_ssh.run_command.side_effect = [
+            ("", "", 1),  # which apt-get fails
+            ("", "", 1),  # which yum fails
+            ("", "", 0),  # which dnf succeeds
+        ]
+
+        result = detect_package_manager(mock_ssh)
+
+        assert result == "dnf"
+        assert mock_ssh.run_command.call_count == 3
+
+    def test_detect_package_manager_unknown(self):
+        """detect_package_manager returns 'unknown' when no package manager found."""
+        mock_ssh = MagicMock()
+        mock_ssh.run_command.return_value = ("", "", 1)  # All fail
+
+        result = detect_package_manager(mock_ssh)
+
+        assert result == "unknown"
+        assert mock_ssh.run_command.call_count == 3
+
+
+class TestEnsureApparmorUtils:
+    """Tests for ensure_apparmor_utils()."""
+
+    def test_already_installed(self):
+        """No action when apparmor_parser is already present."""
+        mock_ssh = MagicMock()
+        mock_ssh.run_command.return_value = ("", "", 0)  # which apparmor_parser succeeds
+
+        ensure_apparmor_utils(mock_ssh)
+
+        # Only one call: which apparmor_parser
+        assert mock_ssh.run_command.call_count == 1
+        mock_ssh.run_sudo_command.assert_not_called()
+
+    def test_not_needed_kernel_apparmor_disabled(self):
+        """No action when kernel AppArmor is disabled."""
+        mock_ssh = MagicMock()
+        mock_ssh.run_command.side_effect = [
+            ("", "", 1),  # which apparmor_parser fails
+            ("N", "", 0),  # /sys/module/apparmor/parameters/enabled returns "N"
+        ]
+
+        ensure_apparmor_utils(mock_ssh)
+
+        assert mock_ssh.run_command.call_count == 2
+        mock_ssh.run_sudo_command.assert_not_called()
+
+    def test_not_needed_kernel_module_missing(self):
+        """No action when /sys/module/apparmor doesn't exist (not enabled)."""
+        mock_ssh = MagicMock()
+        mock_ssh.run_command.side_effect = [
+            ("", "", 1),  # which apparmor_parser fails
+            ("", "", 0),  # cat /sys/module/apparmor/... returns empty stdout
+        ]
+
+        ensure_apparmor_utils(mock_ssh)
+
+        assert mock_ssh.run_command.call_count == 2
+        mock_ssh.run_sudo_command.assert_not_called()
+
+    def test_needed_apt(self):
+        """Installs apparmor via apt-get on apt-based systems."""
+        mock_ssh = MagicMock()
+        mock_ssh.run_command.side_effect = [
+            ("", "", 1),  # which apparmor_parser fails
+            ("Y", "", 0),  # kernel AppArmor enabled
+            ("", "", 0),  # which apt-get succeeds — detect_package_manager
+        ]
+
+        ensure_apparmor_utils(mock_ssh)
+
+        mock_ssh.run_sudo_command.assert_called_once_with(
+            "apt-get update -qq && apt-get install -y -qq apparmor"
+        )
+
+    def test_needed_yum(self):
+        """Installs apparmor via yum on yum-based systems."""
+        mock_ssh = MagicMock()
+        mock_ssh.run_command.side_effect = [
+            ("", "", 1),  # which apparmor_parser fails
+            ("Y", "", 0),  # kernel AppArmor enabled
+            ("", "", 1),  # which apt-get fails — detect_package_manager
+            ("", "", 0),  # which yum succeeds
+        ]
+
+        ensure_apparmor_utils(mock_ssh)
+
+        mock_ssh.run_sudo_command.assert_called_once_with("yum install -y apparmor")
+
+    def test_needed_dnf(self):
+        """Installs apparmor via dnf on dnf-based systems."""
+        mock_ssh = MagicMock()
+        mock_ssh.run_command.side_effect = [
+            ("", "", 1),  # which apparmor_parser fails
+            ("Y", "", 0),  # kernel AppArmor enabled
+            ("", "", 1),  # which apt-get fails — detect_package_manager
+            ("", "", 1),  # which yum fails
+            ("", "", 0),  # which dnf succeeds
+        ]
+
+        ensure_apparmor_utils(mock_ssh)
+
+        mock_ssh.run_sudo_command.assert_called_once_with("dnf install -y apparmor")
+
+    def test_needed_unknown_pkg_mgr(self):
+        """Logs warning and does NOT install when package manager is unknown."""
+        mock_ssh = MagicMock()
+        mock_ssh.run_command.side_effect = [
+            ("", "", 1),  # which apparmor_parser fails
+            ("Y", "", 0),  # kernel AppArmor enabled
+            ("", "", 1),  # which apt-get fails — detect_package_manager
+            ("", "", 1),  # which yum fails
+            ("", "", 1),  # which dnf fails
+        ]
+
+        with patch("docker_utils.logger") as mock_logger:
+            ensure_apparmor_utils(mock_ssh)
+
+        mock_ssh.run_sudo_command.assert_not_called()
+        mock_logger.warning.assert_called_once()
+        warning_msg = mock_logger.warning.call_args[0][0]
+        assert "Unsupported package manager" in warning_msg
+        assert "unknown" in warning_msg

--- a/tests/test_xray_private_key.py
+++ b/tests/test_xray_private_key.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -318,3 +319,32 @@ class TestXrayPrivateKeyMigration:
 
         # Verify flag is set
         assert db.get_migration_flag("xray_private_keys_cleared") == "1"
+
+
+# ----------------------------------------------------------------
+# XrayManager install_protocol AppArmor integration test
+# ----------------------------------------------------------------
+
+
+class TestXrayInstallProtocolAppArmor:
+    """Tests that XrayManager.install_protocol calls ensure_apparmor_utils."""
+
+    def setup_method(self):
+        self.mock_ssh = MagicMock()
+        from app.managers.xray_manager import XrayManager
+
+        self.manager = XrayManager(self.mock_ssh)
+
+    def test_install_protocol_calls_ensure_apparmor_utils(self):
+        """XrayManager.install_protocol calls ensure_apparmor_utils before docker build."""
+        # Mock docker installed and protocol not installed
+        with patch("app.managers.xray_manager.check_docker_installed", return_value=True):
+            with patch.object(self.manager, "check_protocol_installed", return_value=False):
+                self.mock_ssh.run_sudo_command.return_value = ("", "", 0)
+                self.mock_ssh.run_command.return_value = ("", "", 0)
+
+                with patch("app.managers.xray_manager.ensure_apparmor_utils") as mock_fn:
+                    self.manager.install_protocol()
+
+                    # ensure_apparmor_utils must have been called
+                    mock_fn.assert_called_once_with(self.mock_ssh)


### PR DESCRIPTION
## Bug Fix: Docker build fails on bare systems — AppArmor not installed (#205)

### Problem
When installing protocols (AWG, Xray, DNS) on bare/minimal Linux systems, Docker container build fails with:
```
Failed to build container: AppArmor enabled on system but the docker-default profile could not be loaded: running apparmor_parser --version failed
```

### Root Cause
The kernel has AppArmor enabled, but `apparmor_parser` (from the `apparmor` package) is not installed on minimal systems. Docker tries to load the `docker-default` AppArmor profile and fails.

### Solution
- Added `ensure_apparmor_utils(ssh)` to `docker_utils.py` — detects missing `apparmor_parser` and auto-installs the `apparmor` package when the kernel has AppArmor enabled
- Added `detect_package_manager(ssh)` to `docker_utils.py` — shared utility for detecting apt/yum/dnf
- Called `ensure_apparmor_utils()` before every `docker build` in AWG, Xray, and DNS managers
- Refactored `TelemtManager._detect_package_manager()` to use the shared utility

### Testing
- 854 tests pass (13 new)
- black + flake8 clean
- QA approved — no security findings

### Files Changed
- `docker_utils.py` — New functions: `ensure_apparmor_utils()`, `detect_package_manager()`
- `app/managers/awg_manager.py` — Call `ensure_apparmor_utils()` before `docker build`
- `app/managers/xray_manager.py` — Call `ensure_apparmor_utils()` before `docker build`
- `dns_manager.py` — Call `ensure_apparmor_utils()` before `docker build`
- `app/managers/telemt_manager.py` — Refactor `_detect_package_manager()` to use shared utility
- `tests/test_docker_utils.py` — NEW: 11 unit tests
- `tests/test_awg_manager.py` — Added AppArmor integration test
- `tests/test_xray_private_key.py` — Added AppArmor integration test

Closes #205