### PR TITLE
fix: telemt install_protocol chown, port conflict, compose profile

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -115,12 +115,17 @@ USE_LIMIT_CONN=yes
 # Telemt log level (trace, debug, info, warn, error).
 TELEMT_LOG=info
 
-# External port for Telemt (default: 443).
-TELEMT_PORT=443
+# External port for Telemt.
+# Default 18443 avoids port conflict with bunkerweb (which binds 443).
+# Set to 443 only when running telemt WITHOUT the bunkerweb profile.
+TELEMT_PORT=18443
 
 # Host timezone for Telemt timestamps.
 TZ=UTC
 
 # Directory on the host containing Telemt configuration files.
-# Must contain config.toml or other telemt config.
+# MUST contain config.toml before starting telemt. Copy the template, then edit:
+#   mkdir -p telemt-config && cp protocol_telemt/config.toml telemt-config/config.toml
+# Telemt runs as uid 65532 — the config directory must be writable by that user:
+#   chown -R 65532:65532 telemt-config/
 TELEMT_CONFIG_DIR=./telemt-config

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,10 @@ task-leaderboard-template-fix
 # Local work items (not for remote)
 tasks/
 telemt_task_*/
+# Per-instance telemt config (secrets, domain, ad_tags).
+# Copy from protocol_telemt/config.toml and edit before deploy:
+#   mkdir -p telemt-config && cp protocol_telemt/config.toml telemt-config/config.toml
+telemt-config/config.toml
 leaderboard/
 screen/
 WORKLOG.md

--- a/app/managers/telemt_manager.py
+++ b/app/managers/telemt_manager.py
@@ -51,6 +51,13 @@ class TelemtManager:
         """Return the compose directory path on the remote server."""
         return self._compose_dir_path
 
+    def _detect_bunkerweb_running(self) -> bool:
+        """Check if bunkerweb container is running on the remote server."""
+        out, _, _ = self.ssh.run_command(
+            "docker ps --filter name=^bunkerweb$ --format '{{.Names}}'"
+        )
+        return out.strip() == "bunkerweb"
+
     def _api_request(
         self,
         method: str,
@@ -220,6 +227,13 @@ class TelemtManager:
                 timeout=60,
             )
 
+        # Avoid port conflict: bunkerweb binds 443. If bunkerweb is running
+        # and the caller didn't explicitly request 443, use 18443 instead.
+        if port == "443" and self._detect_bunkerweb_running():
+            logger.info("Bunkerweb is running on port 443 — defaulting telemt to port 18443")
+            port = "18443"
+            results.append("Bunkerweb detected on port 443 — using port 18443 for telemt")
+
         # Verify config.toml template integrity
         local_dir = os.path.normpath(
             os.path.join(os.path.dirname(__file__), "..", "..", "protocol_telemt")
@@ -312,10 +326,12 @@ class TelemtManager:
                     f"Expected {local_patched_hash[:16]}..., got {remote_hash[:16]}..."
                 )
 
+        # Change ownership so the telemt container (uid=65532) can write new users
+        self.ssh.run_sudo_command(f"chown -R 65532:65532 {config_dir}/")
+
         # Merge Telemt env vars into .env file
         env_updates: dict[str, str] = {}
-        if port != "443":
-            env_updates["TELEMT_PORT"] = port
+        env_updates["TELEMT_PORT"] = port
         env_updates["TELEMT_CONFIG_DIR"] = self._config_dir()
         if "RUST_LOG" not in env_updates:
             env_updates["RUST_LOG"] = "info"
@@ -323,10 +339,12 @@ class TelemtManager:
         merged_env = self._merge_env_file(env_updates)
         self.ssh.upload_file_sudo(merged_env, f"{self._compose_dir()}/.env")
 
-        # Start the container via compose profile (no --build)
+        # Start the container via compose profile (no --build).
+        # Including --profile bunkerweb is safe: if bunkerweb isn't installed,
+        # compose simply ignores the profile.
         results.append("Starting Telemt container...")
         self.ssh.run_sudo_command(
-            f"cd {self._compose_dir()} && docker compose --profile telemt up -d",
+            f"cd {self._compose_dir()} && docker compose --profile bunkerweb --profile telemt up -d",
             timeout=600,
         )
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -192,7 +192,9 @@ services:
     networks:
       - bw-net
     ports:
-      - "${TELEMT_PORT:-443}:443"
+      # Default 18443 avoids conflict with bunkerweb on 443.
+      # Change TELEMT_PORT in .env if you need 443 (only when bunkerweb profile is OFF).
+      - "${TELEMT_PORT:-18443}:443"
       - "127.0.0.1:9090:9090"
       - "127.0.0.1:9091:9091"
     cap_add:
@@ -209,6 +211,10 @@ services:
     volumes:
       - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
+      # Volume mount for telemt config. The container is read_only, but Docker
+      # bind mounts bypass that restriction — telemt can write new users here.
+      # MUST contain config.toml before starting telemt. Copy the template:
+      #   mkdir -p telemt-config && cp protocol_telemt/config.toml telemt-config/config.toml
       - ${TELEMT_CONFIG_DIR:-./telemt-config}:/etc/telemt/
     deploy:
       resources:

--- a/tests/test_telemt_manager.py
+++ b/tests/test_telemt_manager.py
@@ -1128,11 +1128,13 @@ class TestInstallProtocolComposeProfile:
     @patch("app.managers.telemt_manager.verify_integrity", return_value=True)
     @patch("app.managers.telemt_manager.load_expected_hash", return_value="a" * 64)
     def test_install_protocol_uses_compose_profile(self, mock_load_hash, mock_verify):
-        """install_protocol uses docker compose --profile telemt up -d, no --build."""
+        """install_protocol uses docker compose --profile bunkerweb --profile telemt up -d."""
         self.manager.install_protocol("telemt", port="443")
 
         calls = [call[0][0] for call in self.mock_ssh.run_sudo_command.call_args_list]
-        compose_calls = [c for c in calls if "docker compose --profile telemt up -d" in c]
+        compose_calls = [
+            c for c in calls if "docker compose --profile bunkerweb --profile telemt up -d" in c
+        ]
         assert len(compose_calls) == 1
         # Verify NO --build flag
         assert not any("--build" in c for c in compose_calls)
@@ -1180,7 +1182,7 @@ class TestInstallProtocolComposeProfile:
     @patch("app.managers.telemt_manager.verify_integrity", return_value=True)
     @patch("app.managers.telemt_manager.load_expected_hash", return_value="a" * 64)
     def test_install_protocol_default_port_no_env_override(self, mock_load_hash, mock_verify):
-        """When port=443 (default), TELEMT_PORT is NOT in .env."""
+        """When port=443 (default), TELEMT_PORT IS always written to .env."""
         self.manager.install_protocol("telemt", port="443")
 
         upload_calls = [
@@ -1188,7 +1190,7 @@ class TestInstallProtocolComposeProfile:
         ]
         assert len(upload_calls) >= 1
         env_content = str(upload_calls[0])
-        assert "TELEMT_PORT" not in env_content
+        assert "TELEMT_PORT=443" in env_content
         # TELEMT_CONFIG_DIR should still be present
         assert "TELEMT_CONFIG_DIR=/opt/amnezia/telemt-config" in env_content
 
@@ -1225,6 +1227,8 @@ class TestInstallProtocolComposeProfile:
             ("active", "", 0),
             # check_protocol_installed (container exists)
             ("telemt", "", 0),
+            # _detect_bunkerweb_running (returns empty = not running)
+            ("", "", 0),
             # sha256sum after upload — must match patched hash
             (f"{patched_hash}  /opt/amnezia/telemt-config/config.toml", "", 0),
             # _merge_env_file reads .env
@@ -1236,7 +1240,7 @@ class TestInstallProtocolComposeProfile:
             self.manager.install_protocol("telemt", port="443")
 
         calls = [call[0][0] for call in self.mock_ssh.run_sudo_command.call_args_list]
-        compose_calls = [c for c in calls if "docker compose --profile telemt" in c]
+        compose_calls = [c for c in calls if "docker compose --profile" in c]
         assert len(compose_calls) >= 2
         assert "down" in compose_calls[0]
         assert "up" in compose_calls[-1]


### PR DESCRIPTION
Fixes three bugs in TelemtManager.install_protocol():

1. **CRITICAL: Config dir not writable by telemt** — The telemt container runs as uid=65532 (nonroot) but config.toml was uploaded as root:root with 644 permissions. Telemt could not write new users at runtime. Fix: chown -R 65532:65532 after upload.

2. **Port 443 conflict with bunkerweb** — When bunkerweb is running (binds 443), installing telemt with default port 443 causes a bind error. Fix: auto-detect bunkerweb and switch telemt to 18443. TELEMT_PORT is now always written to .env.

3. **Bunkerweb deactivated on telemt install** — `docker compose --profile telemt up -d` may deactivate bunkerweb containers. Fix: always include `--profile bunkerweb` in the compose up command (harmless when bunkerweb isn't installed).

Also updates docker-compose.yml and .env.example TELEMT_PORT default from 443 to 18443 with documentation.