### PR TITLE
fix: upgrade paramiko 5.0.0, urllib3 2.7.0 to resolve CVEs (#226)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ mdurl==0.1.2
 msgpack==1.1.2
 multicolorcaptcha==1.2.0
 packaging==26.2
-paramiko==4.0.0
+paramiko==5.0.0
 pillow==12.2.0
 platformdirs==4.9.6
 py-serializable==2.1.0
@@ -47,7 +47,7 @@ tomli==2.4.1
 tomli_w==1.2.0
 typing-inspection==0.4.2
 typing_extensions==4.15.0
-urllib3==2.6.3
+urllib3==2.7.0
 uvicorn==0.34.0
 watchfiles==1.1.1
 websockets==16.0


### PR DESCRIPTION
## Changes

Two dependency version bumps in `requirements.txt`:

| Package | Before | After | CVEs Resolved |
|---------|--------|-------|--------------|
| paramiko | 4.0.0 | 5.0.0 | CVE-2026-44405 (SHA-1 in rsakey.py) |
| urllib3 | 2.6.3 | 2.7.0 | CVE-2026-44431 (cross-origin redirect header leak), CVE-2026-44432 (streaming decompression DoS) |

## Verification

- `pip-audit -r requirements.txt` → **0 findings** (exit 0)
- `pytest tests/ --ignore=tests/e2e` → 854 passed
- `black --check .` / `flake8 .` → clean
- No code changes — paramiko 5.0.0 API verified compatible (Ed25519Key.generate() removed but unused by this project)

Closes #226