### PR TITLE
feat: AWG obfuscation profiles for protocol install (#207)

### DIFF
--- a/app/managers/awg_manager.py
+++ b/app/managers/awg_manager.py
@@ -45,6 +45,36 @@ AWG_DEFAULTS = {
     "underload_packet_magic_header": "1766607858",
 }
 
+AWG_PROFILES = {
+    "lite": {
+        "junk_packet_count": (3, 5),
+        "junk_packet_min_size": (5, 15),
+        "junk_packet_max_size": (45, 55),
+        "init_packet_junk_size": (97, 107),
+        "response_packet_junk_size": (17, 27),
+        "cookie_reply_packet_junk_size": (16, 26),
+        "transport_packet_junk_size": (4, 10),
+    },
+    "standard": {
+        "junk_packet_count": (5, 8),
+        "junk_packet_min_size": (30, 80),
+        "junk_packet_max_size": (100, 250),
+        "init_packet_junk_size": (30, 80),
+        "response_packet_junk_size": (30, 80),
+        "cookie_reply_packet_junk_size": (15, 32),
+        "transport_packet_junk_size": (10, 20),
+    },
+    "pro": {
+        "junk_packet_count": (4, 16),
+        "junk_packet_min_size": (50, 256),
+        "junk_packet_max_size": (300, 1000),
+        "init_packet_junk_size": (15, 150),
+        "response_packet_junk_size": (15, 150),
+        "cookie_reply_packet_junk_size": (8, 64),
+        "transport_packet_junk_size": (6, 31),
+    },
+}
+
 
 def generate_wg_keypair():
     """Generate a WireGuard X25519 keypair (private, public) as base64 strings."""
@@ -65,29 +95,111 @@ def generate_psk():
     return b64encode(secrets.token_bytes(32)).decode()
 
 
-def generate_awg_params(use_ranges=False):
-    """Generate random AWG obfuscation parameters."""
+def _generate_quadrant_headers():
+    """Generate H1-H4 using the quadrant method from pumbaX/awg-multi-script.
+
+    Each header is selected from a non-overlapping quadrant of [5, 2^31-1]
+    to maximize entropy spread across the 32-bit space.
+    """
     import random
 
-    jc = random.randint(1, 10)
-    jmin = random.randint(5, 20)
-    jmax = random.randint(jmin + 10, jmin + 50)
-    s1 = random.randint(10, 50)
-    s2 = random.randint(10, 50)
-    s3 = random.randint(10, 50)
-    s4 = random.randint(10, 50)
+    max_val = 2147483647  # 2^31 - 1
+    q_size = max_val // 4
 
-    if use_ranges:
-        # Standard AWG 2.0 headers. Use single large numbers.
+    headers = []
+    for i in range(4):
+        lo = 5 + i * q_size
+        hi = (i + 1) * q_size + (1 if i < 3 else 0)
+        # Pick two random values and use max to ensure minimum separation
+        a = random.randint(lo, hi)
+        b = random.randint(lo, hi)
+        # Minimum span of 1000 between consecutive headers
+        if abs(b - a) < 1000:
+            b = min(hi, max(lo, a + 1000))
+        headers.append(str(random.randint(min(a, b), max(a, b))))
+
+    return {
+        "init_packet_magic_header": headers[0],
+        "response_packet_magic_header": headers[1],
+        "underload_packet_magic_header": headers[2],
+        "transport_packet_magic_header": headers[3],
+    }
+
+
+def generate_awg_params(use_ranges=False, profile=None):
+    """Generate AWG obfuscation parameters.
+
+    Args:
+        use_ranges: If True, use wider header ranges (AWG/AWG2 mode).
+                    If False, use narrower ranges (legacy mode).
+                    Ignored when profile is specified.
+        profile: One of 'lite', 'standard', 'pro'. If provided, uses
+                 profile-specific parameter ranges and quadrant-based
+                 header generation. If None, uses original behavior
+                 (backward compatible).
+    """
+    import random
+
+    if profile and profile in AWG_PROFILES:
+        ranges = AWG_PROFILES[profile]
+        jc = random.randint(*ranges["junk_packet_count"])
+        jmin = random.randint(*ranges["junk_packet_min_size"])
+        jmax_max = ranges["junk_packet_max_size"][1]
+        jmax = random.randint(jmin + 10, jmin + jmax_max)
+        s1 = random.randint(*ranges["init_packet_junk_size"])
+        s2 = random.randint(*ranges["response_packet_junk_size"])
+        # Enforce S1/S2 gap requirement (|S1-S2| >= 10)
+        # Retry up to 100 times; if still failing, s1 +/- 10 and clamp
+        for _ in range(100):
+            if abs(s1 - s2) >= 10:
+                break
+            s2 = random.randint(*ranges["response_packet_junk_size"])
+        else:
+            # Exhausted retries — force gap by moving s2 away from s1
+            s2_min, s2_max = ranges["response_packet_junk_size"]
+            if s1 + 10 <= s2_max:
+                s2 = max(s2_min, s1 + 10)
+            else:
+                s2 = min(s2_max, s1 - 10)
+        s3 = random.randint(*ranges["cookie_reply_packet_junk_size"])
+        s4 = random.randint(*ranges["transport_packet_junk_size"])
+        headers = _generate_quadrant_headers()
+    elif use_ranges:
+        jc = random.randint(1, 10)
+        jmin = random.randint(5, 20)
+        jmax = random.randint(jmin + 10, jmin + 50)
+        s1 = random.randint(10, 50)
+        s2 = random.randint(10, 50)
+        s3 = random.randint(10, 50)
+        s4 = random.randint(10, 50)
         h1 = str(random.randint(1000000000, 4294967295))
         h2 = str(random.randint(1000000000, 4294967295))
         h3 = str(random.randint(1000000000, 4294967295))
         h4 = str(random.randint(1000000000, 4294967295))
+        headers = {
+            "init_packet_magic_header": h1,
+            "response_packet_magic_header": h2,
+            "underload_packet_magic_header": h3,
+            "transport_packet_magic_header": h4,
+        }
     else:
+        jc = random.randint(1, 10)
+        jmin = random.randint(5, 20)
+        jmax = random.randint(jmin + 10, jmin + 50)
+        s1 = random.randint(10, 50)
+        s2 = random.randint(10, 50)
+        s3 = random.randint(10, 50)
+        s4 = random.randint(10, 50)
         h1 = str(random.randint(100000000, 4294967295))
         h2 = str(random.randint(100000000, 4294967295))
         h3 = str(random.randint(100000000, 4294967295))
         h4 = str(random.randint(100000000, 4294967295))
+        headers = {
+            "init_packet_magic_header": h1,
+            "response_packet_magic_header": h2,
+            "underload_packet_magic_header": h3,
+            "transport_packet_magic_header": h4,
+        }
 
     return {
         "junk_packet_count": str(jc),
@@ -97,10 +209,7 @@ def generate_awg_params(use_ranges=False):
         "response_packet_junk_size": str(s2),
         "cookie_reply_packet_junk_size": str(s3),
         "transport_packet_junk_size": str(s4),
-        "init_packet_magic_header": h1,
-        "response_packet_magic_header": h2,
-        "underload_packet_magic_header": h3,
-        "transport_packet_magic_header": h4,
+        **headers,
     }
 
 
@@ -237,7 +346,7 @@ iptables -C FORWARD -j DOCKER-USER 2>/dev/null || iptables -A FORWARD -j DOCKER-
         self.ssh.run_sudo_script(script)
         return True
 
-    def install_protocol(self, protocol_type, port=None, awg_params=None):
+    def install_protocol(self, protocol_type, port=None, awg_params=None, awg_profile=None):
         """
         Full installation of AWG or AWG-Legacy protocol.
         Steps: install docker -> prepare host -> build container ->
@@ -247,7 +356,10 @@ iptables -C FORWARD -j DOCKER-USER 2>/dev/null || iptables -A FORWARD -j DOCKER-
             port = AWG_DEFAULTS["port"]
 
         if awg_params is None:
-            awg_params = generate_awg_params(use_ranges=(protocol_type in (self.AWG, self.AWG2)))
+            awg_params = generate_awg_params(
+                use_ranges=(protocol_type in (self.AWG, self.AWG2)),
+                profile=awg_profile,
+            )
 
         container_name = self._container_name(protocol_type)
         docker_image = self._docker_image(protocol_type)
@@ -390,18 +502,21 @@ iptables -C FORWARD -j DOCKER-USER 2>/dev/null || iptables -A FORWARD -j DOCKER-
         within acceptable bounds. Raises ValueError on invalid input.
         """
         # Numeric params that must be positive integers
+        # Bounds accommodate all AWG obfuscation profiles (lite/standard/pro):
+        # - Pro profile can generate jmax up to 1256 (jmin=256 + jmax_addon=1000)
+        # - Quadrant-based H1-H4 headers start from 5 (not 100M)
         numeric_params = {
             "junk_packet_count": (1, 100),
             "junk_packet_min_size": (1, 1000),
-            "junk_packet_max_size": (1, 1000),
+            "junk_packet_max_size": (1, 1300),
             "init_packet_junk_size": (1, 1000),
             "response_packet_junk_size": (1, 1000),
             "cookie_reply_packet_junk_size": (1, 1000),
             "transport_packet_junk_size": (1, 1000),
-            "init_packet_magic_header": (100000000, 4294967295),
-            "response_packet_magic_header": (100000000, 4294967295),
-            "underload_packet_magic_header": (100000000, 4294967295),
-            "transport_packet_magic_header": (100000000, 4294967295),
+            "init_packet_magic_header": (5, 4294967295),
+            "response_packet_magic_header": (5, 4294967295),
+            "underload_packet_magic_header": (5, 4294967295),
+            "transport_packet_magic_header": (5, 4294967295),
         }
         for key, (min_val, max_val) in numeric_params.items():
             if key not in awg_params:

--- a/app/routers/servers.py
+++ b/app/routers/servers.py
@@ -404,6 +404,13 @@ async def api_install_protocol(
             )
         elif req.protocol == "xray":
             result = await asyncio.to_thread(manager.install_protocol, port=req.port)
+        elif req.protocol in ("awg", "awg2", "awg_legacy"):
+            result = await asyncio.to_thread(
+                manager.install_protocol,
+                protocol_type=req.protocol,
+                port=req.port,
+                awg_profile=req.awg_profile.value if req.awg_profile else None,
+            )
         else:
             result = await asyncio.to_thread(manager.install_protocol, req.protocol, port=req.port)
 

--- a/schemas.py
+++ b/schemas.py
@@ -9,11 +9,26 @@ All request/response models are centralized here for:
 
 from pydantic import BaseModel, Field, field_validator
 from typing import Optional
+from enum import Enum
 import re
 
 # ===== Shared Constants =====
 
 VALID_PROTOCOLS = {"awg", "awg2", "awg_legacy", "xray", "telemt", "dns"}
+
+
+class AWGObfuscationProfile(str, Enum):
+    """AWG obfuscation profile — determines parameter generation ranges.
+
+    lite:      Minimal junk packets, max compatibility (Jc 3-5)
+    standard:  Balanced obfuscation and performance (Jc 5-8) — recommended default
+    pro:       Maximum obfuscation, more overhead (Jc 4-16)
+    """
+
+    lite = "lite"
+    standard = "standard"
+    pro = "pro"
+
 
 # ===== Auth =====
 
@@ -64,6 +79,7 @@ class InstallProtocolRequest(BaseModel):
     tls_emulation: Optional[bool] = None
     tls_domain: Optional[str] = Field(default=None, max_length=128)
     max_connections: Optional[int] = Field(default=None, ge=1, le=100000)
+    awg_profile: Optional[AWGObfuscationProfile] = None
 
     @field_validator("protocol")
     @classmethod

--- a/tests/test_awg_profiles.py
+++ b/tests/test_awg_profiles.py
@@ -1,0 +1,617 @@
+"""
+Tests for AWG obfuscation profile support (Issue #207 Batch 1).
+
+Tests profile-aware parameter generation via generate_awg_params(),
+quadrant header generation, profile integration with install_protocol(),
+and API-level integration with POST /api/servers/{id}/install.
+"""
+
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+from app.managers.awg_manager import (
+    AWG_PROFILES,
+    AWGManager,
+    _generate_quadrant_headers,
+    generate_awg_params,
+)
+from app.utils.helpers import hash_password
+from database import Database
+from dependencies import get_current_user
+from tests.conftest import create_csrf_client
+
+TEST_SECRET_KEY = "test-awg-profiles-...tes!"
+
+
+class TestAWGProfileParams:
+    """Tests for profile-aware parameter generation."""
+
+    def _verify_ranges(self, params, profile_name):
+        """Verify all params are within the expected profile ranges."""
+        ranges = AWG_PROFILES[profile_name]
+        # Jc
+        jc = int(params["junk_packet_count"])
+        assert ranges["junk_packet_count"][0] <= jc <= ranges["junk_packet_count"][1]
+        # Jmin
+        jmin = int(params["junk_packet_min_size"])
+        assert ranges["junk_packet_min_size"][0] <= jmin <= ranges["junk_packet_min_size"][1]
+        # Jmax — must be > jmin, and within expected max bound
+        jmax = int(params["junk_packet_max_size"])
+        jmax_max = ranges["junk_packet_max_size"][1]
+        assert jmax > jmin
+        assert jmax - jmin >= 10
+        assert jmax <= jmin + jmax_max
+        # S1, S2, S3, S4
+        s1 = int(params["init_packet_junk_size"])
+        s2 = int(params["response_packet_junk_size"])
+        s3 = int(params["cookie_reply_packet_junk_size"])
+        s4 = int(params["transport_packet_junk_size"])
+        assert ranges["init_packet_junk_size"][0] <= s1 <= ranges["init_packet_junk_size"][1]
+        assert (
+            ranges["response_packet_junk_size"][0] <= s2 <= ranges["response_packet_junk_size"][1]
+        )
+        assert abs(s1 - s2) >= 10
+        assert (
+            ranges["cookie_reply_packet_junk_size"][0]
+            <= s3
+            <= ranges["cookie_reply_packet_junk_size"][1]
+        )
+        assert (
+            ranges["transport_packet_junk_size"][0] <= s4 <= ranges["transport_packet_junk_size"][1]
+        )
+
+    def test_profile_lite_ranges(self):
+        """Generate 100 params with profile='lite', verify every param is within Lite ranges."""
+        for _ in range(100):
+            params = generate_awg_params(profile="lite")
+            self._verify_ranges(params, "lite")
+
+    def test_profile_standard_ranges(self):
+        """Generate 100 params with profile='standard', verify every param is within Standard ranges."""
+        for _ in range(100):
+            params = generate_awg_params(profile="standard")
+            self._verify_ranges(params, "standard")
+
+    def test_profile_pro_ranges(self):
+        """Generate 100 params with profile='pro', verify every param is within Pro ranges."""
+        for _ in range(100):
+            params = generate_awg_params(profile="pro")
+            self._verify_ranges(params, "pro")
+
+    def test_jmax_always_greater_than_jmin(self):
+        """For all profiles (100 iterations each), jmax > jmin with gap >= 10."""
+        for profile in ("lite", "standard", "pro"):
+            for _ in range(100):
+                params = generate_awg_params(profile=profile)
+                jmin = int(params["junk_packet_min_size"])
+                jmax = int(params["junk_packet_max_size"])
+                assert jmax > jmin, f"{profile}: jmax={jmax} <= jmin={jmin}"
+                assert jmax - jmin >= 10, f"{profile}: gap={jmax-jmin} < 10"
+
+    def test_s1_s2_gap_requirement(self):
+        """For all profiles, |S1-S2| >= 10."""
+        for profile in ("lite", "standard", "pro"):
+            for _ in range(100):
+                params = generate_awg_params(profile=profile)
+                s1 = int(params["init_packet_junk_size"])
+                s2 = int(params["response_packet_junk_size"])
+                assert abs(s1 - s2) >= 10, f"{profile}: |S1-S2| = {abs(s1-s2)}"
+
+    def test_headers_are_unique(self):
+        """H1-H4 are 4 unique values."""
+        for profile in ("lite", "standard", "pro"):
+            for _ in range(50):
+                params = generate_awg_params(profile=profile)
+                headers = {
+                    params["init_packet_magic_header"],
+                    params["response_packet_magic_header"],
+                    params["underload_packet_magic_header"],
+                    params["transport_packet_magic_header"],
+                }
+                assert len(headers) == 4, f"{profile}: headers not unique"
+
+    def test_headers_quadrant_distribution(self):
+        """Each header falls in its respective quadrant."""
+        max_val = 2147483647  # 2^31 - 1
+        q_size = max_val // 4
+
+        for profile in ("lite", "standard", "pro"):
+            for _ in range(50):
+                params = generate_awg_params(profile=profile)
+                h1 = int(params["init_packet_magic_header"])
+                h2 = int(params["response_packet_magic_header"])
+                h3 = int(params["underload_packet_magic_header"])
+                h4 = int(params["transport_packet_magic_header"])
+
+                # H1: quadrant 0 [5, q_size + 1]
+                assert 5 <= h1 <= q_size + 1, f"{profile} H1={h1} out of quadrant 0"
+                # H2: quadrant 1 [q_size + 5, 2*q_size + 1]
+                assert q_size + 5 <= h2 <= 2 * q_size + 1, f"{profile} H2={h2} out of quadrant 1"
+                # H3: quadrant 2 [2*q_size + 5, 3*q_size + 1]
+                assert (
+                    2 * q_size + 5 <= h3 <= 3 * q_size + 1
+                ), f"{profile} H3={h3} out of quadrant 2"
+                # H4: quadrant 3 [3*q_size + 5, max_val]
+                assert 3 * q_size + 5 <= h4 <= max_val, f"{profile} H4={h4} out of quadrant 3"
+
+    def test_all_params_are_strings(self):
+        """Every value in the returned dict is a string."""
+        for profile in ("lite", "standard", "pro"):
+            params = generate_awg_params(profile=profile)
+            assert isinstance(params, dict), f"{profile}: result not a dict"
+            for key, val in params.items():
+                assert isinstance(
+                    val, str
+                ), f"{profile}: {key} is {type(val).__name__}, expected str"
+
+    # --- Backward compatibility tests ---
+
+    def test_default_no_profile_backward_compatible(self):
+        """generate_awg_params() with no profile produces same ranges as before."""
+        # Test without profile: no crash, valid dict, same keys as before
+        params = generate_awg_params()
+        assert isinstance(params, dict)
+        expected_keys = {
+            "junk_packet_count",
+            "junk_packet_min_size",
+            "junk_packet_max_size",
+            "init_packet_junk_size",
+            "response_packet_junk_size",
+            "cookie_reply_packet_junk_size",
+            "transport_packet_junk_size",
+            "init_packet_magic_header",
+            "response_packet_magic_header",
+            "underload_packet_magic_header",
+            "transport_packet_magic_header",
+        }
+        assert set(params.keys()) == expected_keys
+        # All values are strings
+        for v in params.values():
+            assert isinstance(v, str)
+
+        # jc: 1..10, jmin: 5..20, jmax: jmin+10..jmin+50
+        jc = int(params["junk_packet_count"])
+        jmin = int(params["junk_packet_min_size"])
+        jmax = int(params["junk_packet_max_size"])
+        assert 1 <= jc <= 10
+        assert 5 <= jmin <= 20
+        assert jmin + 10 <= jmax <= jmin + 50
+        # s1..s4: 10..50
+        for key in (
+            "init_packet_junk_size",
+            "response_packet_junk_size",
+            "cookie_reply_packet_junk_size",
+            "transport_packet_junk_size",
+        ):
+            s = int(params[key])
+            assert 10 <= s <= 50, f"{key}={s} out of [10,50]"
+        # headers: 100000000..4294967295 (legacy)
+        for key in (
+            "init_packet_magic_header",
+            "response_packet_magic_header",
+            "underload_packet_magic_header",
+            "transport_packet_magic_header",
+        ):
+            h = int(params[key])
+            assert 100000000 <= h <= 4294967295, f"{key}={h} out of legacy range"
+
+    def test_use_ranges_still_works(self):
+        """generate_awg_params(use_ranges=True) still works."""
+        params = generate_awg_params(use_ranges=True)
+        assert isinstance(params, dict)
+        # Headers should be in AWG2 range: 1_000_000_000..4_294_967_295
+        for key in (
+            "init_packet_magic_header",
+            "response_packet_magic_header",
+            "underload_packet_magic_header",
+            "transport_packet_magic_header",
+        ):
+            h = int(params[key])
+            assert 1000000000 <= h <= 4294967295, f"{key}={h} out of AWG2 range"
+
+    def test_invalid_profile_falls_back(self):
+        """generate_awg_params(use_ranges=True, profile='invalid') produces valid params."""
+        params = generate_awg_params(use_ranges=True, profile="invalid")
+        assert isinstance(params, dict)
+        assert "junk_packet_count" in params
+        # Should fall back to use_ranges=True behavior (no crash)
+        for key in (
+            "init_packet_magic_header",
+            "response_packet_magic_header",
+            "underload_packet_magic_header",
+            "transport_packet_magic_header",
+        ):
+            h = int(params[key])
+            assert 1000000000 <= h <= 4294967295
+
+
+class TestQuadrantHeaders:
+    """Tests for _generate_quadrant_headers() helper."""
+
+    def test_returns_dict_with_four_keys(self):
+        headers = _generate_quadrant_headers()
+        assert isinstance(headers, dict)
+        assert len(headers) == 4
+        assert "init_packet_magic_header" in headers
+        assert "response_packet_magic_header" in headers
+        assert "underload_packet_magic_header" in headers
+        assert "transport_packet_magic_header" in headers
+
+    def test_all_values_are_numeric_strings(self):
+        headers = _generate_quadrant_headers()
+        for key, val in headers.items():
+            assert isinstance(val, str), f"{key} is not a string"
+            assert val.isdigit(), f"{key}='{val}' is not numeric"
+
+    def test_headers_in_correct_quadrants(self):
+        """Each header should be in its respective quadrant."""
+        max_val = 2147483647
+        q_size = max_val // 4
+        for _ in range(50):
+            headers = _generate_quadrant_headers()
+            h1 = int(headers["init_packet_magic_header"])
+            h2 = int(headers["response_packet_magic_header"])
+            h3 = int(headers["underload_packet_magic_header"])
+            h4 = int(headers["transport_packet_magic_header"])
+
+            assert 5 <= h1 <= q_size + 1
+            assert q_size + 5 <= h2 <= 2 * q_size + 1
+            assert 2 * q_size + 5 <= h3 <= 3 * q_size + 1
+            assert 3 * q_size + 5 <= h4 <= max_val
+
+    def test_headers_unique(self):
+        """All four headers should be unique."""
+        for _ in range(50):
+            headers = _generate_quadrant_headers()
+            vals = set(headers.values())
+            assert len(vals) == 4
+
+
+class TestAWGManagerInstallProtocolProfile:
+    """Integration tests for install_protocol with awg_profile parameter."""
+
+    def setup_method(self):
+        self.mock_ssh = MagicMock()
+        self.manager = AWGManager(self.mock_ssh)
+
+    def test_install_protocol_accepts_profile(self):
+        """install_protocol with awg_profile='standard' passes profile to generate_awg_params."""
+        self.mock_ssh.run_sudo_command.return_value = ("", "", 0)
+        self.mock_ssh.run_command.return_value = ("", "", 0)
+        self.mock_ssh.upload_file.return_value = None
+
+        with patch("app.managers.awg_manager.check_docker_installed", return_value=True):
+            with patch.object(self.manager, "check_protocol_installed", return_value=False):
+                with patch.object(self.manager, "prepare_host"):
+                    with patch.object(self.manager, "_wait_container_running"):
+                        with patch.object(self.manager, "_configure_container"):
+                            with patch.object(self.manager, "_upload_start_script"):
+                                with patch.object(self.manager, "setup_firewall"):
+                                    with patch("app.managers.awg_manager.ensure_apparmor_utils"):
+                                        with patch(
+                                            "app.managers.awg_manager.generate_awg_params"
+                                        ) as mock_gen:
+                                            mock_gen.return_value = {
+                                                "junk_packet_count": "5",
+                                                "junk_packet_min_size": "40",
+                                                "junk_packet_max_size": "150",
+                                                "init_packet_junk_size": "55",
+                                                "response_packet_junk_size": "45",
+                                                "cookie_reply_packet_junk_size": "24",
+                                                "transport_packet_junk_size": "15",
+                                                "init_packet_magic_header": "100000001",
+                                                "response_packet_magic_header": "600000001",
+                                                "underload_packet_magic_header": "1200000001",
+                                                "transport_packet_magic_header": "1800000001",
+                                            }
+                                            result = self.manager.install_protocol(
+                                                protocol_type="awg",
+                                                port="55424",
+                                                awg_profile="standard",
+                                            )
+
+                                            # Verify generate_awg_params was called with profile
+                                            mock_gen.assert_called_once_with(
+                                                use_ranges=True,
+                                                profile="standard",
+                                            )
+                                            assert result["status"] == "success"
+
+    def test_install_protocol_default_no_profile(self):
+        """install_protocol without awg_profile works as before."""
+        self.mock_ssh.run_sudo_command.return_value = ("", "", 0)
+        self.mock_ssh.run_command.return_value = ("", "", 0)
+        self.mock_ssh.upload_file.return_value = None
+
+        with patch("app.managers.awg_manager.check_docker_installed", return_value=True):
+            with patch.object(self.manager, "check_protocol_installed", return_value=False):
+                with patch.object(self.manager, "prepare_host"):
+                    with patch.object(self.manager, "_wait_container_running"):
+                        with patch.object(self.manager, "_configure_container"):
+                            with patch.object(self.manager, "_upload_start_script"):
+                                with patch.object(self.manager, "setup_firewall"):
+                                    with patch("app.managers.awg_manager.ensure_apparmor_utils"):
+                                        with patch(
+                                            "app.managers.awg_manager.generate_awg_params"
+                                        ) as mock_gen:
+                                            mock_gen.return_value = {
+                                                "junk_packet_count": "3",
+                                                "junk_packet_min_size": "10",
+                                                "junk_packet_max_size": "30",
+                                                "init_packet_junk_size": "20",
+                                                "response_packet_junk_size": "25",
+                                                "cookie_reply_packet_junk_size": "30",
+                                                "transport_packet_junk_size": "35",
+                                                "init_packet_magic_header": "100000001",
+                                                "response_packet_magic_header": "200000001",
+                                                "underload_packet_magic_header": "300000001",
+                                                "transport_packet_magic_header": "400000001",
+                                            }
+                                            result = self.manager.install_protocol(
+                                                protocol_type="awg",
+                                                port="55424",
+                                            )
+
+                                            # No profile => None passed
+                                            mock_gen.assert_called_once_with(
+                                                use_ranges=True,
+                                                profile=None,
+                                            )
+                                            assert result["status"] == "success"
+
+
+class TestApiInstallProfile:
+    """API-level tests for POST /api/servers/{id}/install with awg_profile."""
+
+    def setup_method(self):
+        self.tmp_db = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp_db_path = self.tmp_db.name
+        self.tmp_db.close()
+        os.environ["SECRET_KEY"] = TEST_SECRET_KEY
+        self.db = Database(self.tmp_db_path, secret_key=TEST_SECRET_KEY)
+
+        self.db.create_user(
+            {
+                "id": "admin-1",
+                "username": "admin",
+                "password_hash": hash_password("AdminPass123"),
+                "enabled": True,
+                "traffic_limit": 0,
+                "traffic_used": 0,
+                "role": "admin",
+                "limits": {},
+            }
+        )
+        self.db.create_server(
+            {
+                "name": "Test Server",
+                "host": "10.0.0.1",
+                "username": "root",
+                "password": "***",
+                "ssh_port": 22,
+                "protocols": {},
+            }
+        )
+
+    def teardown_method(self):
+        conn = self.db._get_conn()
+        conn.close()
+        os.unlink(self.tmp_db_path)
+
+    @patch("app.routers.auth.get_db")
+    @patch("app.routers.servers.get_db")
+    def test_api_install_awg_with_profile(self, mock_servers_db, mock_auth_db):
+        """POST /api/servers/{id}/install with protocol=awg and awg_profile=standard."""
+        mock_auth_db.return_value = self.db
+        mock_servers_db.return_value = self.db
+
+        mock_ssh = MagicMock()
+        mock_ssh.connect.return_value = None
+        mock_ssh.run_sudo_command.return_value = ("", "", 0)
+        mock_ssh.run_command.return_value = ("", "", 0)
+        mock_ssh.upload_file.return_value = None
+
+        import app
+
+        client = create_csrf_client()
+
+        # Login
+        login_resp = client.post(
+            "/api/auth/login",
+            json={"username": "admin", "password": "AdminPass123"},
+        )
+        assert login_resp.status_code == 200
+        for hv in login_resp.headers.get_list("set-cookie"):
+            if hv.startswith("session="):
+                client.cookies.set("session", hv.split("session=")[1].split(";")[0])
+                break
+
+        app.app.dependency_overrides[get_current_user] = lambda: self.db.get_user("admin-1")
+        try:
+            with patch("app.routers.servers.get_ssh", return_value=mock_ssh):
+                with patch("app.routers.servers.get_protocol_manager") as mock_get_pm:
+                    mock_manager = MagicMock()
+                    mock_manager.install_protocol.return_value = {
+                        "status": "success",
+                        "protocol": "awg",
+                        "port": "55424",
+                        "awg_params": {"junk_packet_count": "5"},
+                        "log": ["AWG installed"],
+                    }
+                    mock_get_pm.return_value = mock_manager
+
+                    with patch(
+                        "app.managers.awg_manager.check_docker_installed", return_value=True
+                    ):
+                        server_id = self.db.get_all_servers()[0]["id"]
+                        resp = client.post(
+                            f"/api/servers/{server_id}/install",
+                            json={"protocol": "awg", "port": "55424", "awg_profile": "standard"},
+                        )
+                        assert resp.status_code == 200
+                        data = resp.json()
+                        assert data["status"] == "success"
+
+                        # Verify install_protocol was called with awg_profile
+                        mock_manager.install_protocol.assert_called_once_with(
+                            protocol_type="awg",
+                            port="55424",
+                            awg_profile="standard",
+                        )
+        finally:
+            app.app.dependency_overrides.clear()
+
+    @patch("app.routers.auth.get_db")
+    @patch("app.routers.servers.get_db")
+    def test_api_install_awg_without_profile(self, mock_servers_db, mock_auth_db):
+        """POST /api/servers/{id}/install with protocol=awg without awg_profile — backward compat."""
+        mock_auth_db.return_value = self.db
+        mock_servers_db.return_value = self.db
+
+        mock_ssh = MagicMock()
+        mock_ssh.connect.return_value = None
+        mock_ssh.run_sudo_command.return_value = ("", "", 0)
+        mock_ssh.run_command.return_value = ("", "", 0)
+        mock_ssh.upload_file.return_value = None
+
+        import app
+
+        client = create_csrf_client()
+
+        # Login
+        login_resp = client.post(
+            "/api/auth/login",
+            json={"username": "admin", "password": "AdminPass123"},
+        )
+        assert login_resp.status_code == 200
+        for hv in login_resp.headers.get_list("set-cookie"):
+            if hv.startswith("session="):
+                client.cookies.set("session", hv.split("session=")[1].split(";")[0])
+                break
+
+        app.app.dependency_overrides[get_current_user] = lambda: self.db.get_user("admin-1")
+        try:
+            with patch("app.routers.servers.get_ssh", return_value=mock_ssh):
+                with patch("app.routers.servers.get_protocol_manager") as mock_get_pm:
+                    mock_manager = MagicMock()
+                    mock_manager.install_protocol.return_value = {
+                        "status": "success",
+                        "protocol": "awg",
+                        "port": "55424",
+                        "awg_params": {"junk_packet_count": "3"},
+                        "log": ["AWG installed"],
+                    }
+                    mock_get_pm.return_value = mock_manager
+
+                    with patch(
+                        "app.managers.awg_manager.check_docker_installed", return_value=True
+                    ):
+                        server_id = self.db.get_all_servers()[0]["id"]
+                        resp = client.post(
+                            f"/api/servers/{server_id}/install",
+                            json={"protocol": "awg", "port": "55424"},
+                        )
+                        assert resp.status_code == 200
+                        data = resp.json()
+                        assert data["status"] == "success"
+
+                        # Verify install_protocol was called WITHOUT awg_profile
+                        mock_manager.install_protocol.assert_called_once_with(
+                            protocol_type="awg",
+                            port="55424",
+                            awg_profile=None,
+                        )
+        finally:
+            app.app.dependency_overrides.clear()
+
+    @patch("app.routers.auth.get_db")
+    @patch("app.routers.servers.get_db")
+    def test_api_install_awg_invalid_profile_422(self, mock_servers_db, mock_auth_db):
+        """POST with invalid awg_profile returns 422 validation error."""
+        mock_auth_db.return_value = self.db
+        mock_servers_db.return_value = self.db
+
+        import app
+
+        client = create_csrf_client()
+
+        login_resp = client.post(
+            "/api/auth/login",
+            json={"username": "admin", "password": "AdminPass123"},
+        )
+        assert login_resp.status_code == 200
+        for hv in login_resp.headers.get_list("set-cookie"):
+            if hv.startswith("session="):
+                client.cookies.set("session", hv.split("session=")[1].split(";")[0])
+                break
+
+        app.app.dependency_overrides[get_current_user] = lambda: self.db.get_user("admin-1")
+        try:
+            server_id = self.db.get_all_servers()[0]["id"]
+            resp = client.post(
+                f"/api/servers/{server_id}/install",
+                json={"protocol": "awg", "port": "55424", "awg_profile": "invalid_profile"},
+            )
+            assert resp.status_code == 422
+        finally:
+            app.app.dependency_overrides.clear()
+
+    @patch("app.routers.auth.get_db")
+    @patch("app.routers.servers.get_db")
+    def test_api_install_xray_ignores_awg_profile(self, mock_servers_db, mock_auth_db):
+        """POST with protocol=xray and awg_profile — profile is ignored for non-AWG protocols."""
+        mock_auth_db.return_value = self.db
+        mock_servers_db.return_value = self.db
+
+        mock_ssh = MagicMock()
+        mock_ssh.connect.return_value = None
+        mock_ssh.run_sudo_command.return_value = ("", "", 0)
+        mock_ssh.run_command.return_value = ("", "", 0)
+        mock_ssh.upload_file.return_value = None
+
+        import app
+
+        client = create_csrf_client()
+
+        login_resp = client.post(
+            "/api/auth/login",
+            json={"username": "admin", "password": "AdminPass123"},
+        )
+        assert login_resp.status_code == 200
+        for hv in login_resp.headers.get_list("set-cookie"):
+            if hv.startswith("session="):
+                client.cookies.set("session", hv.split("session=")[1].split(";")[0])
+                break
+
+        app.app.dependency_overrides[get_current_user] = lambda: self.db.get_user("admin-1")
+        try:
+            with patch("app.routers.servers.get_ssh", return_value=mock_ssh):
+                with patch("app.routers.servers.get_protocol_manager") as mock_get_pm:
+                    mock_manager = MagicMock()
+                    mock_manager.install_protocol.return_value = {
+                        "status": "success",
+                        "protocol": "xray",
+                        "port": "443",
+                        "awg_params": {},
+                        "log": ["Xray installed"],
+                    }
+                    mock_get_pm.return_value = mock_manager
+
+                    with patch(
+                        "app.managers.awg_manager.check_docker_installed", return_value=True
+                    ):
+                        server_id = self.db.get_all_servers()[0]["id"]
+                        resp = client.post(
+                            f"/api/servers/{server_id}/install",
+                            json={"protocol": "xray", "port": "443", "awg_profile": "standard"},
+                        )
+                        assert resp.status_code == 200
+                        data = resp.json()
+                        assert data["status"] == "success"
+
+                        # Xray should NOT receive awg_profile
+                        call_args = mock_manager.install_protocol.call_args
+                        assert "awg_profile" not in call_args.kwargs
+        finally:
+            app.app.dependency_overrides.clear()


### PR DESCRIPTION
## What
Add backend support for selecting AWG obfuscation profiles (Lite/Standard/Pro) during protocol installation.

4 files changed:
- `app/managers/awg_manager.py` — AWG_PROFILES dict, quadrant headers, profile-aware param generation, validator bounds fix
- `schemas.py` — AWGObfuscationProfile enum, awg_profile field on InstallProtocolRequest
- `app/routers/servers.py` — Pass awg_profile through to AWG/AWG2/AWG_Legacy managers
- `tests/test_awg_profiles.py` — 21 new tests

## Why
Issue #207 — expose AWG obfuscation profiles so users can choose between Lite, Standard, and Pro security presets during install. Inspired by pumbaX/awg-multi-script v6.8.3.

## Technical approach
- AWG_PROFILES dict defines per-profile parameter ranges (jmax, hcnt, hmin, hmax, etc.)
- _generate_quadrant_headers() spreads magic headers across H1-H4 for better entropy
- generate_awg_params() accepts an optional profile param, defaults to Standard for backward compat
- API layer passes the new awg_profile query param through to the manager
- _validate_awg_params() bounds updated: jmax raised to 1300 for Pro, magic header minimum lowered to 5 for quadrant method

## Testing
- 875/875 tests passing
- black + flake8 clean
- QA review: initial REJECTED for validator bounds conflict, fixed and APPROVED on re-review

Closes devops-igor/amnezia-web-ui#207