### PR TITLE
fix: upgrade idna to 3.15+ to resolve CVE-2026-45409

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ h11==0.16.0
 httpcore==1.0.9
 httptools==0.7.1
 httpx==0.28.1
-idna==3.11
+idna>=3.15
 itsdangerous==2.2.0
 Jinja2==3.1.6
 license-expression==30.4.4


### PR DESCRIPTION
## Summary
Upgrades idna from `==3.11` to `>=3.15` in `requirements.txt` to resolve **CVE-2026-45409**.

## Verification
- `pip-audit`: 0 vulnerabilities (CVE-2026-45409 resolved)
- `pytest`: 906/906 passed
- `black` + `flake8`: Clean

## What changed
Single line in `requirements.txt`:
```
-idna==3.11
+idna>=3.15
```

No source code changes. QA approved.

Fixes #232