### PR TITLE
fix: read Telemt client links from data.user.links (resolves #246)

### DIFF
--- a/app/managers/telemt_manager.py
+++ b/app/managers/telemt_manager.py
@@ -506,7 +506,8 @@ class TelemtManager:
             return {"client_id": "", "config": "", "vpn_link": "", "error": error_msg}
 
         data = resp.get("data", {})
-        links = data.get("links", {})
+        user_data = data.get("user", {})
+        links = user_data.get("links", {})
 
         # Use the link from the API (it has correct server IP, port, and secret)
         if links.get("tls"):

--- a/tests/test_telemt_manager.py
+++ b/tests/test_telemt_manager.py
@@ -332,10 +332,12 @@ class TestAddClient:
         mock_api.return_value = {
             "ok": True,
             "data": {
-                "username": "newuser",
-                "secret": "***",
-                "links": {
-                    "tls": ["tg://proxy?server=api.example.com&port=18443&secret=newsecret123"]
+                "user": {
+                    "username": "newuser",
+                    "secret": "***",
+                    "links": {
+                        "tls": ["tg://proxy?server=api.example.com&port=18443&secret=newsecret123"]
+                    },
                 },
             },
         }


### PR DESCRIPTION
## Summary

Fix the Telemt `add_client` method to correctly parse the API response structure.

**Bug:** The `add_client` method in `telemt_manager.py` reads client links from `data.get("links", {})`, but the Telemt POST `/v1/users` API response nests them inside `data["user"]["links"]`.

**Impact:** Adding a Telemt client connection via the API always returns `{"error":"Failed to create connection"}` because all link type checks fail on an empty dict.

## Changes

- `app/managers/telemt_manager.py`: Changed `data.get("links", {})` to `data.get("user", {}).get("links", {})`
- `tests/test_telemt_manager.py`: Updated mock response to match actual Telemt API structure (`data.user.links`)

## Testing

- 906/906 tests pass
- Black + Flake8 clean
- Verified against live Telemt API

Resolves #246