### PR TITLE
fix: add user directive to panel service (resolves #244)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
     ports:
       - "${APP_PORT:-5000}:5000"
     restart: unless-stopped
+    user: "100:101"
     security_opt:
       - no-new-privileges:true
     read_only: true


### PR DESCRIPTION
## Summary

Fix fresh-deploy crash caused by panel data directory having wrong ownership.

**Bug:** On a fresh deploy (empty panel-data directory), the panel container crashes with `sqlite3.OperationalError: unable to open database file` because the data directory is owned by root, but the panel runs as `appuser` (UID 100).

**Root cause:** Docker's volume mount creates the data directory as root by default. The Dockerfile has `USER appuser` but the volume mount happens before the user switch.

**Fix:** Add `user: "100:101"` to the `amnezia-panel` service in docker-compose.yml. This ensures Docker creates the data directory with the correct UID/GID matching the container's appuser.

**Alternative considered:** Documenting a required `chown -R 100:101 /root/panel-data/` step, but this is error-prone and easy to forget. The `user:` directive is self-documenting and automatic.

## Testing
- Verified during full-cycle wipe-and-redeploy: panel crashes without this fix, works with it
- No code changes, only docker-compose.yml

Resolves #244