### PR TITLE
fix: add MTU to awg_params extraction from server config

### DIFF
--- a/app/managers/awg_manager.py
+++ b/app/managers/awg_manager.py
@@ -783,6 +783,7 @@ tail -f /dev/null
         # Mapping from server config keys to our param dictionary keys
         param_map = {
             "ListenPort": "port",
+            "MTU": "mtu",
             "Jc": "junk_packet_count",
             "Jmin": "junk_packet_min_size",
             "Jmax": "junk_packet_max_size",


### PR DESCRIPTION
## Summary

The `_get_awg_params_from_config` `param_map` was missing `MTU`, so the `/api/servers/{id}/check` endpoint returned `awg_params` without `mtu` even though the server config has `MTU = 1320`. The UI profile display (PR #249) checks for `p.mtu` but it was never populated.

## Fix

Add `"MTU": "mtu"` to the `param_map` dict in `_get_awg_params_from_config()`.

## Testing

- 53/53 AWG manager tests pass
- flake8 clean

Part of #207