### PR TITLE
fix: remove inconsistent background/padding styling from AWG and Telemt install modal sections (#253)

### DIFF
--- a/templates/server.html
+++ b/templates/server.html
@@ -232,8 +232,7 @@
                 <div class="form-hint" id="installPortHint">{{ _('port_default_hint') }}</div>
             </div>
 
-            <div id="telemtOptions"
-                style="display:none; padding: var(--space-md); background: rgba(0,0,0,0.03); border-radius: var(--radius-md); margin-bottom: var(--space-md);">
+            <div id="telemtOptions" style="display:none; margin-bottom: var(--space-md);">
                 <div class="form-group">
                     <label class="form-label" style="display:flex; justify-content:space-between; align-items:center;">
                         {{ _('tls_emulation') }}
@@ -255,8 +254,7 @@
                 </div>
             </div>
 
-            <div id="awgOptions"
-                style="display:none; padding: var(--space-md); background: rgba(0,0,0,0.03); border-radius: var(--radius-md); margin-bottom: var(--space-md);">
+            <div id="awgOptions" style="display:none; margin-bottom: var(--space-md);">
                 <div class="form-group">
                     <label class="form-label">{{ _('awg_obfuscation_profile') }}</label>
                     <select class="form-input" id="installAwgProfile">


### PR DESCRIPTION
## What
Removed inline CSS (padding, background, border-radius) from the `#telemtOptions` and `#awgOptions` wrapper divs in the install modal.

## Why
The Obfuscation Profile, CPS Protocol, and TLS Emulation sections had wrapper styling that made them visually inconsistent with the Port field and other form inputs. Removing the inline chrome lets all form fields share the same visual treatment.

## Technical approach
- Stripped `padding`, `background`, and `border-radius` inline styles from two `<div>` elements in `templates/server.html`
- Kept `display:none;` and `margin-bottom: var(--space-md);` which are needed for toggle logic and spacing
- No JavaScript changes — show/hide toggle logic verified untouched (6 assignments)

## Testing
- QA approved (see QA_REVIEW.md)
- 901 unit tests pass
- Black and Flake8 clean
- No Python code changes — pure HTML inline style removal

Fixes #253