### PR TITLE
Fix: Telemt connections always show "Stopped" in UI (resolves #255)

### DIFF
--- a/app/managers/telemt_manager.py
+++ b/app/managers/telemt_manager.py
@@ -387,7 +387,9 @@ class TelemtManager:
             username = user.get("username", "")
             secret = user.get("secret", "")
             links = user.get("links", {})
-            enabled = bool(secret)  # Non-empty secret means enabled
+            enabled = user.get(
+                "in_runtime", secret != ""
+            )  # Use API's in_runtime, fallback to secret
 
             tg_link = ""
             if links.get("tls"):

--- a/tests/test_telemt_manager.py
+++ b/tests/test_telemt_manager.py
@@ -216,6 +216,7 @@ class TestGetClients:
             "data": [
                 {
                     "username": "alice",
+                    "in_runtime": True,
                     "secret": "abc123def456",
                     "links": {"tls": ["tg://proxy?server=example.com&port=443&secret=abc123"]},
                     "total_octets": 1000,
@@ -264,6 +265,7 @@ class TestGetClients:
             "data": [
                 {
                     "username": "bob",
+                    "in_runtime": False,
                     "secret": "",  # Empty secret = disabled
                     "links": {"classic": ["tg://proxy?server=example.com&port=443&secret="]},
                     "total_octets": 500,
@@ -283,6 +285,7 @@ class TestGetClients:
             "data": [
                 {
                     "username": "carol",
+                    "in_runtime": True,
                     "secret": "***",
                     "links": {"tls": ["tg://proxy?..."]},
                     "total_octets": 10000,
@@ -306,6 +309,7 @@ class TestGetClients:
             "data": [
                 {
                     "username": "dave",
+                    "in_runtime": True,
                     "secret": "xyz789",
                     "links": {
                         "tls": [],
@@ -318,6 +322,44 @@ class TestGetClients:
 
         clients = self.manager.get_clients("telemt")
         assert clients[0]["userData"]["tg_link"] == "tg://secure-link"
+
+    @patch.object(TelemtManager, "_api_request")
+    def test_get_clients_in_runtime_false(self, mock_api):
+        """User with in_runtime=False should be disabled regardless of secret."""
+        mock_api.return_value = {
+            "ok": True,
+            "data": [
+                {"username": "bob", "in_runtime": False, "secret": "some_secret", "links": {}}
+            ],
+        }
+        clients = self.manager.get_clients("telemt")
+        assert clients[0]["enabled"] is False
+
+    @patch.object(TelemtManager, "_api_request")
+    def test_get_clients_in_runtime_missing_with_secret(self, mock_api):
+        """Fallback: no in_runtime field, uses secret to determine enabled."""
+        mock_api.return_value = {
+            "ok": True,
+            "data": [
+                {
+                    "username": "alice",
+                    "secret": "abc123",
+                    "links": {"tls": ["tg://proxy?..."]},
+                }
+            ],
+        }
+        clients = self.manager.get_clients("telemt")
+        assert clients[0]["enabled"] is True
+
+    @patch.object(TelemtManager, "_api_request")
+    def test_get_clients_in_runtime_missing_without_secret(self, mock_api):
+        """Fallback: no in_runtime, no secret → disabled."""
+        mock_api.return_value = {
+            "ok": True,
+            "data": [{"username": "bob", "links": {}}],
+        }
+        clients = self.manager.get_clients("telemt")
+        assert clients[0]["enabled"] is False
 
 
 class TestAddClient:
@@ -766,6 +808,7 @@ class TestGetClientConfig:
                 "data": [
                     {
                         "username": "dave",
+                        "in_runtime": True,
                         "secret": "***",
                         "links": {
                             "tls": [


### PR DESCRIPTION
## Problem

All Telemt (MTProto) connections show as **Stopped** (red badge) in the web UI, even though they are active and working correctly.

## Root Cause

The Telemt `GET /v1/users` API does **not** include a `secret` field in the list response — it is omitted for security. The code at `telemt_manager.py:390` used `bool(secret)` to determine enabled status, which always evaluated to `False` since `secret` was always an empty string.

The API provides an `in_runtime` boolean field instead, which indicates whether the user is active in the running Telemt config.

## Fix

**One line change:** `enabled = bool(secret)` → `enabled = user.get("in_runtime", secret != "")`

This uses the API authoritative `in_runtime` field with a backward-compatible fallback to `bool(secret)` for API responses that do not include `in_runtime`.

## Testing

- 91/91 telemt tests pass
- 3 new tests: `in_runtime=False`, fallback with `secret`, fallback without `secret`
- 5 existing test mocks updated with `in_runtime` field
- black + flake8 clean
- QA APPROVED

Closes #255