### PR TITLE
Fix AWG migration regression — connections disappear after update

### DIFF
--- a/app/routers/connections.py
+++ b/app/routers/connections.py
@@ -11,7 +11,7 @@ from fastapi.responses import JSONResponse
 from app.utils.helpers import _sanitize_error, generate_vpn_link, get_ssh, get_protocol_manager
 from config import get_db
 from dependencies import get_current_user
-from schemas import MyAddConnectionRequest, RenameConnectionRequest
+from schemas import MyAddConnectionRequest, RenameConnectionRequest, normalize_protocol
 
 logger = logging.getLogger(__name__)
 
@@ -131,7 +131,8 @@ async def api_my_add_connection(
         return JSONResponse({"error": "Server not found"}, status_code=404)
 
     # Verify protocol is installed
-    proto_info = server.get("protocols", {}).get(req.protocol, {})
+    normalized_proto = normalize_protocol(req.protocol)
+    proto_info = server.get("protocols", {}).get(normalized_proto, {})
     if not proto_info or not proto_info.get("installed", False):
         return JSONResponse(
             {"error": f"Protocol {req.protocol} is not installed on this server"},
@@ -158,13 +159,13 @@ async def api_my_add_connection(
     try:
         ssh = get_ssh(server)
         await asyncio.to_thread(ssh.connect)
-        manager = get_protocol_manager(ssh, req.protocol)
+        manager = get_protocol_manager(ssh, normalized_proto)
 
         # Create client on remote server
-        if req.protocol == "telemt":
+        if normalized_proto == "telemt":
             result = await asyncio.to_thread(
                 manager.add_client,
-                req.protocol,
+                normalized_proto,
                 req.name,
                 server["host"],
                 port,
@@ -174,7 +175,7 @@ async def api_my_add_connection(
             )
         else:
             result = await asyncio.to_thread(
-                manager.add_client, req.protocol, req.name, server["host"], port
+                manager.add_client, normalized_proto, req.name, server["host"], port
             )
 
         if result.get("client_id"):
@@ -182,7 +183,7 @@ async def api_my_add_connection(
                 "id": str(uuid.uuid4()),
                 "user_id": user["id"],
                 "server_id": req.server_id,
-                "protocol": req.protocol,
+                "protocol": normalized_proto,
                 "client_id": result["client_id"],
                 "name": req.name,
                 "created_at": now.isoformat(),
@@ -227,15 +228,16 @@ async def api_my_connection_config(
         server = db.get_server_by_id(sid)
         if server is None:
             return JSONResponse({"error": "Server not found"}, status_code=404)
-        proto_info = server.get("protocols", {}).get(conn["protocol"], {})
+        normalized_proto = normalize_protocol(conn["protocol"])
+        proto_info = server.get("protocols", {}).get(normalized_proto, {})
         port = proto_info.get("port", "55424")
         ssh = get_ssh(server)
         await asyncio.to_thread(ssh.connect)
         # Use appropriate manager for the protocol
-        manager = get_protocol_manager(ssh, conn["protocol"])
+        manager = get_protocol_manager(ssh, normalized_proto)
         config = await asyncio.to_thread(
             manager.get_client_config,
-            conn["protocol"],
+            normalized_proto,
             conn["client_id"],
             server["host"],
             port,

--- a/app/services/background_orchestrator.py
+++ b/app/services/background_orchestrator.py
@@ -13,6 +13,7 @@ from app.services.background import perform_mass_operations
 from app.services.background import sync_users_with_remnawave
 from app.utils.helpers import get_protocol_manager
 from app.utils.helpers import get_ssh
+from schemas import normalize_protocol
 
 logger = logging.getLogger(__name__)
 
@@ -97,7 +98,10 @@ class BackgroundTaskOrchestrator:
                             client_bytes[c.get("clientId")] = {"rx": rx, "tx": tx}
 
                         for uc in conns_by_server[sid]:
-                            if uc["protocol"] == proto and uc["client_id"] in client_bytes:
+                            if (
+                                normalize_protocol(uc["protocol"]) == proto
+                                and uc["client_id"] in client_bytes
+                            ):
                                 curr_rx = client_bytes[uc["client_id"]]["rx"]
                                 curr_tx = client_bytes[uc["client_id"]]["tx"]
                                 last_rx = uc.get("last_rx")

--- a/app/services/user_operations.py
+++ b/app/services/user_operations.py
@@ -8,6 +8,7 @@ from typing import List
 
 from config import get_db
 from app.utils.helpers import get_ssh, get_protocol_manager
+from schemas import normalize_protocol
 
 logger = logging.getLogger(__name__)
 
@@ -41,8 +42,9 @@ async def perform_delete_user(user_id: str):
             ssh = get_ssh(server)
             await asyncio.to_thread(ssh.connect)
             for uc in conns:
-                manager = get_protocol_manager(ssh, uc["protocol"])
-                await asyncio.to_thread(manager.remove_client, uc["protocol"], uc["client_id"])
+                normalized_proto = normalize_protocol(uc["protocol"])
+                manager = get_protocol_manager(ssh, normalized_proto)
+                await asyncio.to_thread(manager.remove_client, normalized_proto, uc["client_id"])
             await asyncio.to_thread(ssh.disconnect)
         except Exception as e:
             logger.warning(

--- a/config.py
+++ b/config.py
@@ -146,3 +146,27 @@ def migrate_awg_protocol_names():
         logger.info("AWG legacy migration complete: %d server(s) updated", migrated)
     else:
         logger.info("AWG legacy migration: no servers needed migration")
+
+    # Also migrate user_connections.protocol column
+    conn_migrated = 0
+    for alias in ("awg2", "awg_legacy"):
+        with db._connection() as conn:
+            rows = conn.execute(
+                "SELECT id FROM user_connections WHERE protocol = ?", (alias,)
+            ).fetchall()
+            if rows:
+                conn.execute(
+                    "UPDATE user_connections SET protocol = 'awg' WHERE protocol = ?",
+                    (alias,),
+                )
+                conn.commit()
+                conn_migrated += len(rows)
+                logger.info(
+                    "Migrated %d connection(s) with protocol '%s' -> 'awg'",
+                    len(rows),
+                    alias,
+                )
+    if conn_migrated:
+        logger.info("AWG connection migration complete: %d connection(s) updated", conn_migrated)
+    else:
+        logger.info("AWG connection migration: no connections needed migration")

--- a/schemas.py
+++ b/schemas.py
@@ -16,6 +16,17 @@ import re
 
 VALID_PROTOCOLS = {"awg", "xray", "telemt", "dns"}
 
+# Protocol aliases: legacy names that should be treated as their modern equivalent
+PROTOCOL_ALIASES = {"awg2": "awg", "awg_legacy": "awg"}
+
+
+def normalize_protocol(proto: str) -> str:
+    """Normalize legacy protocol names to their modern equivalents.
+
+    Maps 'awg2' and 'awg_legacy' to 'awg'. All other values pass through.
+    """
+    return PROTOCOL_ALIASES.get(proto, proto)
+
 
 class AWGObfuscationProfile(str, Enum):
     """AWG obfuscation profile — determines parameter generation ranges.

--- a/tests/e2e/test_connections.py
+++ b/tests/e2e/test_connections.py
@@ -97,7 +97,7 @@ def test_add_connection(authenticated_page: Page, base_url: str, csrf_token: str
     add_conn_result = api_post(
         page,
         f"/api/users/{user_id}/connections/add",
-        {"server_id": server_id, "protocol": "awg2", "name": "e2e_test_connection"},
+        {"server_id": server_id, "protocol": "awg", "name": "e2e_test_connection"},
         csrf_token,
     )
 
@@ -149,7 +149,7 @@ def test_connection_config_and_qr(authenticated_page: Page, base_url: str, csrf_
     conn_result = api_post(
         page,
         f"/api/users/{user_id}/connections/add",
-        {"server_id": server_id, "protocol": "awg2", "name": "e2e_config_test"},
+        {"server_id": server_id, "protocol": "awg", "name": "e2e_config_test"},
         csrf_token,
     )
 
@@ -213,7 +213,7 @@ def test_toggle_connection(authenticated_page: Page, base_url: str, csrf_token: 
     conn_result = api_post(
         page,
         f"/api/users/{user_id}/connections/add",
-        {"server_id": server_id, "protocol": "awg2", "name": "e2e_toggle_test"},
+        {"server_id": server_id, "protocol": "awg", "name": "e2e_toggle_test"},
         csrf_token,
     )
 
@@ -289,7 +289,7 @@ def test_delete_connection(authenticated_page: Page, base_url: str, csrf_token: 
     conn_result = api_post(
         page,
         f"/api/users/{user_id}/connections/add",
-        {"server_id": server_id, "protocol": "awg2", "name": "e2e_delete_conn"},
+        {"server_id": server_id, "protocol": "awg", "name": "e2e_delete_conn"},
         csrf_token,
     )
 

--- a/tests/e2e/test_my_connections.py
+++ b/tests/e2e/test_my_connections.py
@@ -107,7 +107,7 @@ def test_create_connection(
     conn_result = api_post(
         page,
         f"/api/users/{user_id}/connections/add",
-        {"server_id": server_id, "protocol": "awg2", "name": "e2e_user_conn"},
+        {"server_id": server_id, "protocol": "awg", "name": "e2e_user_conn"},
         csrf_token,
     )
 
@@ -150,7 +150,7 @@ def test_view_connection_config(
     conn_result = api_post(
         page,
         f"/api/users/{user_id}/connections/add",
-        {"server_id": server_id, "protocol": "awg2", "name": "e2e_view_conn"},
+        {"server_id": server_id, "protocol": "awg", "name": "e2e_view_conn"},
         csrf_token,
     )
 

--- a/tests/e2e/test_users.py
+++ b/tests/e2e/test_users.py
@@ -214,7 +214,7 @@ def test_add_user_connection(authenticated_page: Page, base_url: str, csrf_token
         f"/api/users/{user_id}/connections/add",
         {
             "server_id": server_id,
-            "protocol": "awg2",
+            "protocol": "awg",
             "name": "e2e_user_conn",
         },
         csrf_token,

--- a/tests/test_awg_migration.py
+++ b/tests/test_awg_migration.py
@@ -1,0 +1,179 @@
+"""Unit tests for AWG protocol migration and normalize_protocol."""
+
+import pytest
+from unittest.mock import MagicMock
+
+from schemas import normalize_protocol
+from config import migrate_awg_protocol_names
+
+
+class TestNormalizeProtocol:
+    """Tests for normalize_protocol() in schemas.py."""
+
+    def test_normalize_awg2_returns_awg(self):
+        """normalize_protocol('awg2') returns 'awg'."""
+        assert normalize_protocol("awg2") == "awg"
+
+    def test_normalize_awg_legacy_returns_awg(self):
+        """normalize_protocol('awg_legacy') returns 'awg'."""
+        assert normalize_protocol("awg_legacy") == "awg"
+
+    def test_normalize_xray_passthrough(self):
+        """normalize_protocol('xray') returns 'xray' (passthrough)."""
+        assert normalize_protocol("xray") == "xray"
+
+    def test_normalize_awg_passthrough(self):
+        """normalize_protocol('awg') returns 'awg' (already correct)."""
+        assert normalize_protocol("awg") == "awg"
+
+    def test_normalize_telemt_passthrough(self):
+        """normalize_protocol('telemt') returns 'telemt' (passthrough)."""
+        assert normalize_protocol("telemt") == "telemt"
+
+    def test_normalize_unknown_passthrough(self):
+        """normalize_protocol('unknown_proto') returns 'unknown_proto' (passthrough)."""
+        assert normalize_protocol("unknown_proto") == "unknown_proto"
+
+
+class TestMigrateAWGProtocolNames:
+    """Tests for migrate_awg_protocol_names() in config.py."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_db_mock(self, monkeypatch):
+        """Mock the database so we don't touch real data."""
+        self.mock_db = MagicMock()
+        monkeypatch.setattr("config.get_db", lambda: self.mock_db)
+
+    def _setup_mock_server(self, protocols: dict) -> dict:
+        """Create a mock server dict with given protocols."""
+        return {"id": 1, "protocols": protocols}
+
+    def test_migrates_awg2_server_to_awg(self):
+        """Server with protocols: {'awg2': {...}} gets migrated to {'awg': {...}}."""
+        server = self._setup_mock_server({"awg2": {"installed": True, "port": "55424"}})
+        self.mock_db.get_all_servers.return_value = [server]
+        self.mock_db._connection.return_value.__enter__.return_value = MagicMock()
+
+        migrate_awg_protocol_names()
+
+        self.mock_db.update_server.assert_called_once()
+        call_args = self.mock_db.update_server.call_args
+        assert call_args[0][0] == 1  # server id
+        updated_protocols = call_args[0][1]["protocols"]
+        assert "awg2" not in updated_protocols
+        assert "awg" in updated_protocols
+
+    def test_migrates_awg_legacy_server_to_awg(self):
+        """Server with protocols: {'awg_legacy': {...}} gets migrated to {'awg': {...}}."""
+        server = self._setup_mock_server({"awg_legacy": {"installed": True, "port": "55424"}})
+        self.mock_db.get_all_servers.return_value = [server]
+        self.mock_db._connection.return_value.__enter__.return_value = MagicMock()
+
+        migrate_awg_protocol_names()
+
+        self.mock_db.update_server.assert_called_once()
+        call_args = self.mock_db.update_server.call_args
+        assert call_args[0][0] == 1
+        updated_protocols = call_args[0][1]["protocols"]
+        assert "awg_legacy" not in updated_protocols
+        assert "awg" in updated_protocols
+
+    def test_awg_server_stays_unchanged(self):
+        """Server with protocols: {'awg': {...}} stays unchanged."""
+        server = self._setup_mock_server({"awg": {"installed": True, "port": "55424"}})
+        self.mock_db.get_all_servers.return_value = [server]
+        self.mock_db._connection.return_value.__enter__.return_value = MagicMock()
+
+        migrate_awg_protocol_names()
+
+        self.mock_db.update_server.assert_not_called()
+
+    def test_migrates_connection_awg2_to_awg(self):
+        """Connection with protocol: 'awg2' gets migrated to 'awg'."""
+        server = self._setup_mock_server({"awg": {"installed": True}})
+        self.mock_db.get_all_servers.return_value = [server]
+        mock_conn = MagicMock()
+
+        def execute_side_effect(sql, params=()):
+            result = MagicMock()
+            params_str = params[0] if params else ""
+            if "awg2" in sql or "awg2" == params_str:
+                result.fetchall.return_value = [{"id": "conn-1"}]
+            else:
+                result.fetchall.return_value = []
+            return result
+
+        mock_conn.execute.side_effect = execute_side_effect
+        self.mock_db._connection.return_value.__enter__.return_value = mock_conn
+
+        migrate_awg_protocol_names()
+
+        # Should have called execute with UPDATE for awg2
+        update_calls = [
+            call
+            for call in mock_conn.execute.call_args_list
+            if "UPDATE user_connections" in str(call.args[0])
+        ]
+        assert len(update_calls) == 1
+
+    def test_migrates_connection_awg_legacy_to_awg(self):
+        """Connection with protocol: 'awg_legacy' gets migrated to 'awg'."""
+        server = self._setup_mock_server({"awg": {"installed": True}})
+        self.mock_db.get_all_servers.return_value = [server]
+        mock_conn = MagicMock()
+
+        def execute_side_effect(sql, params=()):
+            result = MagicMock()
+            params_str = params[0] if params else ""
+            if "awg2" in sql or "awg2" == params_str:
+                result.fetchall.return_value = []
+            elif "awg_legacy" in sql or "awg_legacy" == params_str:
+                result.fetchall.return_value = [{"id": "conn-2"}]
+            else:
+                result.fetchall.return_value = []
+            return result
+
+        mock_conn.execute.side_effect = execute_side_effect
+        self.mock_db._connection.return_value.__enter__.return_value = mock_conn
+
+        migrate_awg_protocol_names()
+
+        # Should have called UPDATE with awg_legacy
+        update_calls = [
+            call
+            for call in mock_conn.execute.call_args_list
+            if "UPDATE user_connections" in str(call.args[0])
+        ]
+        assert len(update_calls) == 1
+
+    def test_connection_awg_stays_unchanged(self):
+        """Connection with protocol: 'awg' stays unchanged."""
+        server = self._setup_mock_server({"awg": {"installed": True}})
+        self.mock_db.get_all_servers.return_value = [server]
+        mock_conn = MagicMock()
+        # Both alias queries return empty
+        mock_conn.execute.return_value.fetchall.return_value = []
+        self.mock_db._connection.return_value.__enter__.return_value = mock_conn
+
+        migrate_awg_protocol_names()
+
+        # No UPDATE should have been executed on user_connections
+        update_calls = [
+            call
+            for call in mock_conn.execute.call_args_list
+            if "UPDATE user_connections" in str(call.args[0])
+        ]
+        assert len(update_calls) == 0
+
+    def test_no_connections_needed(self):
+        """When no connections need migration, log the appropriate message."""
+        server = self._setup_mock_server({"awg": {"installed": True}})
+        self.mock_db.get_all_servers.return_value = [server]
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.return_value = []
+        self.mock_db._connection.return_value.__enter__.return_value = mock_conn
+
+        migrate_awg_protocol_names()
+
+        # No UPDATE statements issued
+        self.mock_db.update_server.assert_not_called()


### PR DESCRIPTION
## What
Fix a regression where existing AmneziaWG connections disappear from the UI and leaderboard traffic stops propagating after updating the platform.

## Why
Commit 8c0edff renamed `awg2` → `awg` as the sole protocol type and migrated `servers.protocols` JSON keys but missed the `user_connections.protocol` column. Existing connections with `protocol = "awg2"` became orphaned — invisible in the UI, skipped by traffic sync, and broken for config lookups.

## Technical approach
1. Added `PROTOCOL_ALIASES` and `normalize_protocol()` in `schemas.py` as a runtime safety net
2. Extended `migrate_awg_protocol_names()` in `config.py` to also migrate `user_connections.protocol`
3. Applied `normalize_protocol()` in all codepaths that compare or look up protocols:
   - `background_orchestrator.py` (traffic sync)
   - `connections.py` (add + config endpoints)
   - `user_operations.py` (delete user)
4. Updated E2E test fixtures from `"awg2"` → `"awg"`
5. Added 13 new unit tests for migration and normalization

## Testing
- 914 unit tests pass (including 13 new migration tests)
- black + flake8 clean
- QA review approved